### PR TITLE
Minor doc update

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **This is a prototype library currently under heavy development. It does not currently have stable releases, and as such will likely be modified significantly in backwards compatibility breaking ways until beta release (targeting early 2022). If you have suggestions on the API or use cases you would like to be covered, please open a GitHub issue. We would love to hear thoughts and feedback.**
 
-TorchArrow is a [torch](https://github.com/pytorch/pytorch).Tensor-like, [Pandas](https://github.com/pandas-dev/pandas) inspired Python DataFrame library for data preprocessing in deep learning. It supports multiple execution runtimes and [Arrow](https://github.com/apache/arrow) as a common format.
+TorchArrow is a [torch](https://github.com/pytorch/pytorch).Tensor-like Python DataFrame library for data preprocessing in deep learning. It supports multiple execution runtimes and [Arrow](https://github.com/apache/arrow) as a common format.
 
 It plans to provide:
 
@@ -84,4 +84,3 @@ We hope to sufficiently expand the library, harden APIs, and gather feedback to 
 ## License
 
 TorchArrow is BSD licensed, as found in the [LICENSE](LICENSE) file.
-

--- a/tutorial.ipynb
+++ b/tutorial.ipynb
@@ -32,7 +32,7 @@
     "last_server_session_id": "2b839861-3e9c-4dc2-b535-72671f7645f3",
     "last_kernel_id": "119a376c-d69f-47dd-9679-89b4e1651884",
     "last_base_url": "https://devvm1776.ftw0.facebook.com:8090/",
-    "last_msg_id": "4cd56e95-a92c567935138befea88bb19_285"
+    "last_msg_id": "25ba9dfa-e3e59522f839bd7b5346dde9_285"
   },
   "nbformat": 4,
   "nbformat_minor": 2,
@@ -40,15 +40,15 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "73cd86a3-a72a-4261-8e67-e41f323a8bfb",
-        "showInput": false,
+        "originalKey": "3a82cbb3-b213-44c0-bacf-0ce05063994a",
+        "showInput": true,
         "code_folding": [],
         "hidden_ranges": []
       },
       "source": [
         "# TorchArrow in 10 minutes\n",
         "\n",
-        "TorchArrow is a torch.Tensor-like, Pandas inspired Python DataFrame library for data preprocessing in deep learning. It supports multiple execution runtimes and Arrow as a common format.\n",
+        "TorchArrow is a torch.Tensor-like Python DataFrame library for data preprocessing in deep learning. It supports multiple execution runtimes and Arrow as a common memory format.\n",
         "\n",
         "(Remark. In case the following looks familiar, it is with gratitude that portions of this tutorial were borrowed and adapted from the 10 Minutes to Pandas (and CuDF) tutorial.)\n",
         "\n",
@@ -58,7 +58,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "451c655c-3659-411f-a2a6-167fe85b488f"
+        "originalKey": "47503d4c-cd45-4d4d-a8e5-a1824e0d7977"
       },
       "source": [
         "The TorchArrow library consists of 3 parts: \n",
@@ -73,13 +73,13 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "e0a514c3-aaa6-48c7-8630-1b1e9d202f72",
+        "originalKey": "94c1c035-5201-461f-8f16-c3748496535f",
         "code_folding": [],
         "hidden_ranges": [],
         "collapsed": false,
-        "requestMsgId": "94c1c035-5201-461f-8f16-c3748496535f",
-        "executionStartTime": 1633988330923,
-        "executionStopTime": 1633988331523
+        "requestMsgId": "e476c5ee-9485-4767-b30e-acefc169acd7",
+        "executionStartTime": 1634146943448,
+        "executionStopTime": 1634146944781
       },
       "source": [
         "import torcharrow as ta\n",
@@ -92,7 +92,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "2a588acd-5f17-4584-a7df-c046f870bcbb"
+        "originalKey": "50a5e636-c4db-46d7-930b-b0a9aa9728fc"
       },
       "source": [
         "## Constructing data: Columns\n",
@@ -104,11 +104,11 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "ce7aef00-da2c-4ef2-a35e-9a3452fe8d80",
+        "originalKey": "2be4585e-dd9b-4b6f-ad1b-41ec23e55a4e",
         "collapsed": false,
-        "requestMsgId": "2be4585e-dd9b-4b6f-ad1b-41ec23e55a4e",
-        "executionStartTime": 1633988331535,
-        "executionStopTime": 1633988331711,
+        "requestMsgId": "a9350c1e-66fd-400a-8ba0-a29faec76f8e",
+        "executionStartTime": 1634146944817,
+        "executionStopTime": 1634146944978,
         "code_folding": [],
         "hidden_ranges": []
       },
@@ -163,7 +163,7 @@
             }
           },
           "metadata": {
-            "bento_obj_id": "139691096007728"
+            "bento_obj_id": "139832115858064"
           },
           "execution_count": 2
         }
@@ -172,7 +172,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "0ed4e1c8-7afc-46ae-8c20-af82b76b31bd"
+        "originalKey": "3649c29b-0e6b-4b64-82a8-22ddf4594249"
       },
       "source": [
         "In Pandas each Series has an index, here depicted as the first column. Note also that the inferred type is float and not int, since in Pandas None implicitly  promotes an int list to a float series."
@@ -181,7 +181,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "68c90431-fa1e-4838-a2fd-0bd98a0d836c"
+        "originalKey": "6591dc54-5bc4-4fc7-9037-18ed59e251ae"
       },
       "source": [
         "TorchArrow has a much more precise type system:"
@@ -190,11 +190,11 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "47ecc86e-b576-4f98-8395-75606033501f",
+        "originalKey": "fb49942c-b725-4bd9-aa0e-3156aa40ab59",
         "collapsed": false,
-        "requestMsgId": "fb49942c-b725-4bd9-aa0e-3156aa40ab59",
-        "executionStartTime": 1633988331714,
-        "executionStopTime": 1633988331799,
+        "requestMsgId": "6423ff78-8866-47eb-a6c2-cf952014ecea",
+        "executionStartTime": 1634146945042,
+        "executionStopTime": 1634146945053,
         "code_folding": [],
         "hidden_ranges": []
       },
@@ -211,7 +211,7 @@
             "text/plain": "0  1\n1  2\n2  None\n3  4\ndtype: Int64(nullable=True), length: 4, null_count: 1"
           },
           "metadata": {
-            "bento_obj_id": "139691096008304"
+            "bento_obj_id": "139832152394528"
           },
           "execution_count": 3
         }
@@ -220,7 +220,51 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "fde4a7b6-3a80-421a-a730-12f9a6d0a1dd",
+        "originalKey": "b623ed6e-d9bd-4710-91ce-e1a567f97350",
+        "showInput": false,
+        "customInput": null,
+        "code_folding": [],
+        "hidden_ranges": []
+      },
+      "source": [
+        "TorchArrow creates CPU column by default, which is supported by [Velox](https://github.com/facebookincubator/velox) backend."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "80efeea3-ce16-44c3-9365-4f6120c24338",
+        "showInput": true,
+        "customInput": null,
+        "code_folding": [],
+        "hidden_ranges": [],
+        "collapsed": false,
+        "requestMsgId": "7e017323-27dd-4048-9c79-d33b23cdd3c4",
+        "executionStartTime": 1634146945064,
+        "executionStopTime": 1634146945208
+      },
+      "source": [
+        "s.device\n",
+        ""
+      ],
+      "execution_count": 4,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "'cpu'"
+          },
+          "metadata": {
+            "bento_obj_id": "139833745243312"
+          },
+          "execution_count": 4
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "originalKey": "fc30f67f-9f60-4d0a-950f-19593a7dc6f8",
         "showInput": false,
         "code_folding": [],
         "hidden_ranges": []
@@ -235,19 +279,19 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "488717d5-3f3d-4bca-918d-c84ecf9a4b1b",
+        "originalKey": "4346ceb7-148c-4d42-820d-1960b32337b5",
         "code_folding": [],
         "hidden_ranges": [],
         "collapsed": false,
-        "requestMsgId": "4346ceb7-148c-4d42-820d-1960b32337b5",
-        "executionStartTime": 1633988331808,
-        "executionStopTime": 1633988331894
+        "requestMsgId": "81ea28a6-ddb8-49c9-a224-bffd4ccec1fe",
+        "executionStartTime": 1634146945218,
+        "executionStopTime": 1634146945398
       },
       "source": [
         "len(s), s.count(), s.null_count()\n",
         ""
       ],
-      "execution_count": 4,
+      "execution_count": 5,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -255,16 +299,16 @@
             "text/plain": "(4, 3, 1)"
           },
           "metadata": {
-            "bento_obj_id": "139691091033152"
+            "bento_obj_id": "139832115862976"
           },
-          "execution_count": 4
+          "execution_count": 5
         }
       ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "ed6f3065-e448-4188-83e1-b9fed2d69b67",
+        "originalKey": "0cc9f285-0722-4839-ab3c-0bbb53ef2675",
         "showInput": false,
         "customInput": null,
         "code_folding": [],
@@ -277,22 +321,22 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "465f1b0c-b340-4e63-851d-29f167e65504",
+        "originalKey": "3b6e4d17-172a-4725-8188-bc991420b704",
         "showInput": true,
         "customInput": null,
         "code_folding": [],
         "hidden_ranges": [],
         "collapsed": false,
-        "requestMsgId": "3b6e4d17-172a-4725-8188-bc991420b704",
-        "executionStartTime": 1633988331970,
-        "executionStopTime": 1633988331978
+        "requestMsgId": "d1ea8682-6adc-4b7c-9d6a-9e15c4de0563",
+        "executionStartTime": 1634146945408,
+        "executionStopTime": 1634146945418
       },
       "source": [
         "ss = ta.Column([2.718, 3.14, 42.42])\n",
         "ss\n",
         ""
       ],
-      "execution_count": 5,
+      "execution_count": 6,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -300,16 +344,16 @@
             "text/plain": "0   2.718\n1   3.14\n2  42.42\ndtype: float32, length: 3, null_count: 0"
           },
           "metadata": {
-            "bento_obj_id": "139691090197088"
+            "bento_obj_id": "139832116030768"
           },
-          "execution_count": 5
+          "execution_count": 6
         }
       ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "448213ff-12f5-4856-b432-970e84b13f2c",
+        "originalKey": "f9955c2e-4b35-4102-9ff7-2118d3337d3d",
         "showInput": false
       },
       "source": [
@@ -319,11 +363,11 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "54555153-8c73-4bac-ab4a-440ddd674e17",
+        "originalKey": "fd9365ca-6cb7-4b40-9490-77345cf70ab2",
         "collapsed": false,
-        "requestMsgId": "fd9365ca-6cb7-4b40-9490-77345cf70ab2",
-        "executionStartTime": 1633988332063,
-        "executionStopTime": 1633988332071,
+        "requestMsgId": "6ff08fb0-371a-4cc6-a1d5-40d4b4740c6b",
+        "executionStartTime": 1634146945426,
+        "executionStopTime": 1634146945434,
         "code_folding": [],
         "hidden_ranges": []
       },
@@ -332,7 +376,7 @@
         "sf.dtype\n",
         ""
       ],
-      "execution_count": 6,
+      "execution_count": 7,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -340,16 +384,16 @@
             "text/plain": "List(item_dtype=String(nullable=False), nullable=False, fixed_size=-1)"
           },
           "metadata": {
-            "bento_obj_id": "139691332408704"
+            "bento_obj_id": "139832116065184"
           },
-          "execution_count": 6
+          "execution_count": 7
         }
       ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "d2a20c9e-9d14-41eb-8dd5-5c2eb80f3c77"
+        "originalKey": "6ca67b7d-73f2-450a-bbc4-c893658e3976"
       },
       "source": [
         "And here is a column of average climate data, one map per continent, with city as key and yearly average min and max temperature:\n",
@@ -359,11 +403,11 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "ff7431cb-89a3-4cfa-9820-56fe4122b1b3",
+        "originalKey": "263c5539-3599-48d1-9b3a-115bfa61fc46",
         "collapsed": false,
-        "requestMsgId": "263c5539-3599-48d1-9b3a-115bfa61fc46",
-        "executionStartTime": 1633988332081,
-        "executionStopTime": 1633988332174,
+        "requestMsgId": "2a5d9ee0-1d65-4c1c-a0d7-26afe02aa3ad",
+        "executionStartTime": 1634146945446,
+        "executionStopTime": 1634146945455,
         "code_folding": [],
         "hidden_ranges": []
       },
@@ -377,24 +421,24 @@
         "mf\n",
         ""
       ],
-      "execution_count": 7,
+      "execution_count": 8,
       "outputs": [
         {
           "output_type": "execute_result",
           "data": {
-            "text/plain": "0  {'helsinki': [-1.3, 21.5], 'moscow': [-4.0, 24.3]}\n1  {'algiers': [11.2, 25.2], 'kinshasa': [22.2, 26.8]}\ndtype: Map(string, List(float32)), length: 2, null_count: 0"
+            "text/plain": "0  {'helsinki': [-1.2999999523162842, 21.5], 'moscow': [-4.0, 24.299999237060547]}\n1  {'algiers': [11.199999809265137, 25.200000762939453], 'kinshasa': [22.200000762939453, 26.799999237060547]}\ndtype: Map(string, List(float32)), length: 2, null_count: 0"
           },
           "metadata": {
-            "bento_obj_id": "139691332409952"
+            "bento_obj_id": "139832116028656"
           },
-          "execution_count": 7
+          "execution_count": 8
         }
       ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "7364bc17-f164-40db-90a5-1d408946f991"
+        "originalKey": "57b2c79a-4536-4c7f-a358-78ac2e12096c"
       },
       "source": [
         "### Append and concat"
@@ -403,7 +447,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "ec96f726-921c-42eb-b9d3-30442097c0a7",
+        "originalKey": "0bde1c7e-f951-4ec3-a1ff-515f2eafad75",
         "showInput": false,
         "code_folding": [],
         "hidden_ranges": []
@@ -415,20 +459,20 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "9019133f-dc38-4091-9855-bf660e4636e6",
+        "originalKey": "aa4e87f4-9416-4f2a-9b54-198da9c22e3a",
         "code_folding": [],
         "hidden_ranges": [],
         "collapsed": false,
-        "requestMsgId": "aa4e87f4-9416-4f2a-9b54-198da9c22e3a",
-        "executionStartTime": 1633988332183,
-        "executionStopTime": 1633988332196
+        "requestMsgId": "69d4bc16-703a-4400-87df-04cf495f3f8a",
+        "executionStartTime": 1634146945467,
+        "executionStopTime": 1634146945603
       },
       "source": [
         "sf = sf.append([[\"I\", \"am\", \"fine\", \"and\", \"you\"]])\n",
         "sf\n",
         ""
       ],
-      "execution_count": 8,
+      "execution_count": 9,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -436,16 +480,16 @@
             "text/plain": "0  ['hello', 'world']\n1  ['how', 'are', 'you']\n2  ['I', 'am', 'fine', 'and', 'you']\ndtype: List(string), length: 3, null_count: 0"
           },
           "metadata": {
-            "bento_obj_id": "139691332409760"
+            "bento_obj_id": "139832116030432"
           },
-          "execution_count": 8
+          "execution_count": 9
         }
       ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "73c22f23-0c63-49d6-8397-619f4d81d03f",
+        "originalKey": "b16dac95-9f8c-4876-8b28-98e00fb6669a",
         "showInput": false,
         "customInput": null,
         "code_folding": [],
@@ -458,28 +502,28 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "44469ea4-25e2-4a7c-ae67-8438d94ba76c",
+        "originalKey": "03678b24-be97-4b04-8cbd-fa6a2830ea5c",
         "showInput": true,
         "customInput": null,
         "code_folding": [],
         "hidden_ranges": [],
         "collapsed": false,
-        "requestMsgId": "03678b24-be97-4b04-8cbd-fa6a2830ea5c",
-        "executionStartTime": 1633988332301,
-        "executionStopTime": 1633988332321
+        "requestMsgId": "b0df3069-7f0a-479b-ac23-fb1fcd38bc8f",
+        "executionStartTime": 1634146945659,
+        "executionStopTime": 1634146945665
       },
       "source": [
         "# TODO: Fix this!\n",
         "# sf = sf.concat([ta.Column(\"I\", \"am\", \"fine\", \"too\")]\n",
         ""
       ],
-      "execution_count": 9,
+      "execution_count": 10,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "95fb93b9-4e30-4934-9987-1f5a71783c25",
+        "originalKey": "7541224a-ef7c-4884-87b8-783be9d88ba5",
         "showInput": false
       },
       "source": [
@@ -491,13 +535,13 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "263b8b05-4e16-43c2-9045-dbb7f16464c1",
+        "originalKey": "fdbb0894-4b50-4bc1-8e71-29c7683956e8",
         "code_folding": [],
         "hidden_ranges": [],
         "collapsed": false,
-        "requestMsgId": "fdbb0894-4b50-4bc1-8e71-29c7683956e8",
-        "executionStartTime": 1633988332403,
-        "executionStopTime": 1633988332417
+        "requestMsgId": "25aa1e61-4bdb-49c8-bd10-d1da21420583",
+        "executionStartTime": 1634146945673,
+        "executionStopTime": 1634146945735
       },
       "source": [
         "df = ta.DataFrame(\n",
@@ -506,7 +550,7 @@
         "df\n",
         ""
       ],
-      "execution_count": 10,
+      "execution_count": 11,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -514,45 +558,7 @@
             "text/plain": "  index    a    b    c\n-------  ---  ---  ---\n      0    0    6    0\n      1    1    5    1\n      2    2    4    2\n      3    3    3    3\n      4    4    2    4\n      5    5    1    5\n      6    6    0    6\ndtype: Struct([Field('a', int64), Field('b', int64), Field('c', int64)]), count: 7, null_count: 0"
           },
           "metadata": {
-            "bento_obj_id": "139691090026016"
-          },
-          "execution_count": 10
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "originalKey": "bc9bb72a-693b-4ecc-a83c-87c59727a152"
-      },
-      "source": [
-        "To access a dataframes columns write:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "originalKey": "f5995657-5ae2-4741-b056-83993295114b",
-        "collapsed": false,
-        "requestMsgId": "3f290b55-eb1a-445a-ab57-93aadff013b4",
-        "executionStartTime": 1633988332419,
-        "executionStopTime": 1633988332431,
-        "code_folding": [],
-        "hidden_ranges": []
-      },
-      "source": [
-        "df.columns\n",
-        ""
-      ],
-      "execution_count": 11,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": "['a', 'b', 'c']"
-          },
-          "metadata": {
-            "bento_obj_id": "139691089840576"
+            "bento_obj_id": "139832116030864"
           },
           "execution_count": 11
         }
@@ -561,7 +567,45 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "9a4e94b1-54c6-4ec9-b705-63d5bf22ad3e",
+        "originalKey": "c2aa25da-562a-412d-8e70-6e033e81259f"
+      },
+      "source": [
+        "To access a dataframes columns write:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "3f290b55-eb1a-445a-ab57-93aadff013b4",
+        "collapsed": false,
+        "requestMsgId": "5356a1de-5a4a-4be7-99a3-66a08a3cb120",
+        "executionStartTime": 1634146945788,
+        "executionStopTime": 1634146945829,
+        "code_folding": [],
+        "hidden_ranges": []
+      },
+      "source": [
+        "df.columns\n",
+        ""
+      ],
+      "execution_count": 12,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "['a', 'b', 'c']"
+          },
+          "metadata": {
+            "bento_obj_id": "139832115342784"
+          },
+          "execution_count": 12
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "originalKey": "bb21cdb2-0991-4f87-b298-83176cee9351",
         "showInput": false,
         "code_folding": [],
         "hidden_ranges": []
@@ -575,11 +619,11 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "9962ee05-cc01-4a94-ba07-6ddd2530e003",
+        "originalKey": "2542d3ec-69ea-4c63-9f89-8f3a95755a43",
         "collapsed": false,
-        "requestMsgId": "2542d3ec-69ea-4c63-9f89-8f3a95755a43",
-        "executionStartTime": 1633988332435,
-        "executionStopTime": 1633988332525,
+        "requestMsgId": "424f0969-95f7-4bac-b0e3-5f220b4eb4c9",
+        "executionStartTime": 1634146945887,
+        "executionStopTime": 1634146945912,
         "code_folding": [],
         "hidden_ranges": []
       },
@@ -588,7 +632,7 @@
         "df\n",
         ""
       ],
-      "execution_count": 12,
+      "execution_count": 13,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -596,16 +640,16 @@
             "text/plain": "  index    a    b    c    d\n-------  ---  ---  ---  ---\n      0    0    6    0   99\n      1    1    5    1  100\n      2    2    4    2  101\n      3    3    3    3  102\n      4    4    2    4  103\n      5    5    1    5  104\n      6    6    0    6  105\ndtype: Struct([Field('a', int64), Field('b', int64), Field('c', int64), Field('d', int64)]), count: 7, null_count: 0"
           },
           "metadata": {
-            "bento_obj_id": "139691090026016"
+            "bento_obj_id": "139832116030864"
           },
-          "execution_count": 12
+          "execution_count": 13
         }
       ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "fc987684-b884-4964-8c4a-3969472406bd",
+        "originalKey": "006cc907-0beb-4b16-b0aa-6033ec3ef628",
         "showInput": false,
         "customInput": null,
         "code_folding": [],
@@ -618,22 +662,22 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "63ae6a60-b641-4c20-aaed-b81cbcf0c368",
+        "originalKey": "8ddeb5dc-db38-4914-b497-17fd2716dde9",
         "showInput": true,
         "customInput": null,
         "code_folding": [],
         "hidden_ranges": [],
         "collapsed": false,
-        "requestMsgId": "8ddeb5dc-db38-4914-b497-17fd2716dde9",
-        "executionStartTime": 1633988332622,
-        "executionStopTime": 1633988332632
+        "requestMsgId": "25404e3c-4c12-431a-90d3-39b6468d03ad",
+        "executionStartTime": 1634146945914,
+        "executionStopTime": 1634146945977
       },
       "source": [
         "df[\"c\"] = df[\"b\"] * 2\n",
         "df\n",
         ""
       ],
-      "execution_count": 13,
+      "execution_count": 14,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -641,16 +685,16 @@
             "text/plain": "  index    a    b    c    d\n-------  ---  ---  ---  ---\n      0    0    6   12   99\n      1    1    5   10  100\n      2    2    4    8  101\n      3    3    3    6  102\n      4    4    2    4  103\n      5    5    1    2  104\n      6    6    0    0  105\ndtype: Struct([Field('a', int64), Field('b', int64), Field('c', int64), Field('d', int64)]), count: 7, null_count: 0"
           },
           "metadata": {
-            "bento_obj_id": "139691090026016"
+            "bento_obj_id": "139832116030864"
           },
-          "execution_count": 13
+          "execution_count": 14
         }
       ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "7dd388a3-3a73-49cc-972c-07419f5d1e8b",
+        "originalKey": "f47b07c3-372f-4b59-af21-83e0e5dccf46",
         "showInput": false,
         "customInput": null,
         "code_folding": [],
@@ -663,22 +707,22 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "2f6a9393-3776-48e6-9584-0fa590dccc5d",
+        "originalKey": "f06344a5-d82a-4d2e-a9bb-d0b9db2ee919",
         "showInput": true,
         "customInput": null,
         "code_folding": [],
         "hidden_ranges": [],
         "collapsed": false,
-        "requestMsgId": "f06344a5-d82a-4d2e-a9bb-d0b9db2ee919",
-        "executionStartTime": 1633988332640,
-        "executionStopTime": 1633988332729
+        "requestMsgId": "9b3dbf9a-475f-406e-8c80-0fa16cffacb3",
+        "executionStartTime": 1634146945981,
+        "executionStopTime": 1634146946044
       },
       "source": [
         "df = df.append([(7, 77, 777, 7777), (8, 88, 888, 8888)])\n",
         "df\n",
         ""
       ],
-      "execution_count": 14,
+      "execution_count": 15,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -686,16 +730,16 @@
             "text/plain": "  index    a    b    c     d\n-------  ---  ---  ---  ----\n      0    0    6   12    99\n      1    1    5   10   100\n      2    2    4    8   101\n      3    3    3    6   102\n      4    4    2    4   103\n      5    5    1    2   104\n      6    6    0    0   105\n      7    7   77  777  7777\n      8    8   88  888  8888\ndtype: Struct([Field('a', int64), Field('b', int64), Field('c', int64), Field('d', int64)]), count: 9, null_count: 0"
           },
           "metadata": {
-            "bento_obj_id": "139691089878800"
+            "bento_obj_id": "139832115409728"
           },
-          "execution_count": 14
+          "execution_count": 15
         }
       ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "49c91668-021b-4a21-a2c2-0e3783e9a43d"
+        "originalKey": "b15b6ac7-93b0-4dbf-9ea6-49dab9c41199"
       },
       "source": [
         "Dataframes can be nested. Here is a Dataframe having sub-dataframes. \n",
@@ -705,13 +749,13 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "eced179d-f5b2-47e8-83cc-308d50c22fbb",
+        "originalKey": "e7557899-8bff-474d-ae29-14535eb0f8cd",
         "code_folding": [],
         "hidden_ranges": [],
         "collapsed": false,
-        "requestMsgId": "e7557899-8bff-474d-ae29-14535eb0f8cd",
-        "executionStartTime": 1633988332738,
-        "executionStopTime": 1633988332745
+        "requestMsgId": "2475bb57-78f8-47d8-8924-3c9d8a78cf15",
+        "executionStartTime": 1634146946085,
+        "executionStopTime": 1634146946144
       },
       "source": [
         "df_inner = ta.DataFrame({\"b1\": [11, 22, 33], \"b2\": [111, 222, 333]})\n",
@@ -719,7 +763,7 @@
         "df_outer\n",
         ""
       ],
-      "execution_count": 15,
+      "execution_count": 16,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -727,16 +771,16 @@
             "text/plain": "  index    a  b\n-------  ---  ---------\n      0    1  (11, 111)\n      1    2  (22, 222)\n      2    3  (33, 333)\ndtype: Struct([Field('a', int64), Field('b', Struct([Field('b1', int64), Field('b2', int64)]))]), count: 3, null_count: 0"
           },
           "metadata": {
-            "bento_obj_id": "139691089925984"
+            "bento_obj_id": "139832115393632"
           },
-          "execution_count": 15
+          "execution_count": 16
         }
       ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "2df9095e-601c-4347-84f3-942e7d3ab967",
+        "originalKey": "42337a3f-23bc-4230-922d-9935c69f0c37",
         "showInput": false,
         "customInput": null,
         "code_folding": [],
@@ -751,7 +795,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "dac4f933-1973-450b-8f0a-644578fc0c4f",
+        "originalKey": "1105b29d-2384-4cc4-859d-994240cc6482",
         "showInput": false
       },
       "source": [
@@ -763,50 +807,14 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "3180fca1-a87b-4fb9-bb7f-860b18a0c99a",
+        "originalKey": "498a15e2-d232-43e2-b4a9-0d291270a0dc",
         "collapsed": false,
-        "requestMsgId": "498a15e2-d232-43e2-b4a9-0d291270a0dc",
-        "executionStartTime": 1633988332833,
-        "executionStopTime": 1633988332846
+        "requestMsgId": "e8f8628d-62bd-4be9-8580-67ef26f210c6",
+        "executionStartTime": 1634146946428,
+        "executionStopTime": 1634146946438
       },
       "source": [
         "df.head(2)\n",
-        ""
-      ],
-      "execution_count": 16,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": "  index    a    b    c    d\n-------  ---  ---  ---  ---\n      0    0    6   12   99\n      1    1    5   10  100\ndtype: Struct([Field('a', int64), Field('b', int64), Field('c', int64), Field('d', int64)]), count: 2, null_count: 0"
-          },
-          "metadata": {
-            "bento_obj_id": "139691089937024"
-          },
-          "execution_count": 16
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "originalKey": "8d0e888a-9b61-4ed7-9620-42664bf47ca7"
-      },
-      "source": [
-        "Or return the last n rows"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "originalKey": "dfecd6ab-dbb1-4b00-9bea-bb7411fd2a1c",
-        "collapsed": false,
-        "requestMsgId": "126216fd-309d-4103-ba7e-adf5838f8fee",
-        "executionStartTime": 1633988332927,
-        "executionStopTime": 1633988332936
-      },
-      "source": [
-        "df.tail(1)\n",
         ""
       ],
       "execution_count": 17,
@@ -814,10 +822,10 @@
         {
           "output_type": "execute_result",
           "data": {
-            "text/plain": "  index    a    b    c     d\n-------  ---  ---  ---  ----\n      0    8   88  888  8888\ndtype: Struct([Field('a', int64), Field('b', int64), Field('c', int64), Field('d', int64)]), count: 1, null_count: 0"
+            "text/plain": "  index    a    b    c    d\n-------  ---  ---  ---  ---\n      0    0    6   12   99\n      1    1    5   10  100\ndtype: Struct([Field('a', int64), Field('b', int64), Field('c', int64), Field('d', int64)]), count: 2, null_count: 0"
           },
           "metadata": {
-            "bento_obj_id": "139691089927088"
+            "bento_obj_id": "139832115417488"
           },
           "execution_count": 17
         }
@@ -826,23 +834,23 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "e193fa96-4ee5-4132-85a2-ecd32e653a45"
+        "originalKey": "00c88f87-3605-4170-a561-0f98b26f9d6d"
       },
       "source": [
-        "or sort the values before hand."
+        "Or return the last n rows"
       ]
     },
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "76772c2e-85eb-464f-9b7d-ff647c7d5915",
+        "originalKey": "126216fd-309d-4103-ba7e-adf5838f8fee",
         "collapsed": false,
-        "requestMsgId": "b450dd3b-8287-4738-b239-7009dc1d3f40",
-        "executionStartTime": 1633988333017,
-        "executionStopTime": 1633988333031
+        "requestMsgId": "468c7b8a-a517-40c3-882e-6eb9f02b9767",
+        "executionStartTime": 1634146946450,
+        "executionStopTime": 1634146946460
       },
       "source": [
-        "df.sort(by=[\"c\", \"b\"]).head(2)\n",
+        "df.tail(1)\n",
         ""
       ],
       "execution_count": 18,
@@ -850,10 +858,10 @@
         {
           "output_type": "execute_result",
           "data": {
-            "text/plain": "  index    a    b    c    d\n-------  ---  ---  ---  ---\n      0    6    0    0  105\n      1    5    1    2  104\ndtype: Struct([Field('a', int64), Field('b', int64), Field('c', int64), Field('d', int64)]), count: 2, null_count: 0"
+            "text/plain": "  index    a    b    c     d\n-------  ---  ---  ---  ----\n      0    8   88  888  8888\ndtype: Struct([Field('a', int64), Field('b', int64), Field('c', int64), Field('d', int64)]), count: 1, null_count: 0"
           },
           "metadata": {
-            "bento_obj_id": "139691089934560"
+            "bento_obj_id": "139832115442640"
           },
           "execution_count": 18
         }
@@ -862,7 +870,43 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "595c3b1c-3730-46f3-9102-a4eea81084dd"
+        "originalKey": "38b01f3f-30ef-49cf-a3ff-50689b4f39d6"
+      },
+      "source": [
+        "or sort the values before hand."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "b450dd3b-8287-4738-b239-7009dc1d3f40",
+        "collapsed": false,
+        "requestMsgId": "68367688-b6c8-4bec-827e-d83e2c14d574",
+        "executionStartTime": 1634146946470,
+        "executionStopTime": 1634146946516
+      },
+      "source": [
+        "df.sort(by=[\"c\", \"b\"]).head(2)\n",
+        ""
+      ],
+      "execution_count": 19,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  index    a    b    c    d\n-------  ---  ---  ---  ---\n      0    6    0    0  105\n      1    5    1    2  104\ndtype: Struct([Field('a', int64), Field('b', int64), Field('c', int64), Field('d', int64)]), count: 2, null_count: 0"
+          },
+          "metadata": {
+            "bento_obj_id": "139832115393392"
+          },
+          "execution_count": 19
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "originalKey": "7b28b1f1-b4d3-490c-8b20-86a0733027ca"
       },
       "source": [
         "Sorting can be controlled not only by which columns to sort on, but also whether to sort ascending or descending, and how to deal with nulls, are they listed first or last.  \n",
@@ -879,16 +923,16 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "c5b04b10-17a3-470d-8305-fbfaa9ecff07",
+        "originalKey": "435a2616-45ba-4e0f-b081-b016f176ce87",
         "collapsed": false,
-        "requestMsgId": "435a2616-45ba-4e0f-b081-b016f176ce87",
-        "executionStartTime": 1633988333034,
-        "executionStopTime": 1633988333120
+        "requestMsgId": "dcb2b825-9441-4363-87b1-ce2ca13890e1",
+        "executionStartTime": 1634146946527,
+        "executionStopTime": 1634146946541
       },
       "source": [
         "df['a']"
       ],
-      "execution_count": 19,
+      "execution_count": 20,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -896,16 +940,16 @@
             "text/plain": "0  0\n1  1\n2  2\n3  3\n4  4\n5  5\n6  6\n7  7\n8  8\ndtype: int64, length: 9, null_count: 0"
           },
           "metadata": {
-            "bento_obj_id": "139691089877216"
+            "bento_obj_id": "139832115417776"
           },
-          "execution_count": 19
+          "execution_count": 20
         }
       ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "92611ff7-e990-4c05-becb-574d9aede91b",
+        "originalKey": "f880caf6-e1ea-4f75-990c-787f76e0d709",
         "showInput": false,
         "code_folding": [],
         "hidden_ranges": []
@@ -917,16 +961,16 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "61f580f0-e2e8-419d-9508-9a40d32215bf",
+        "originalKey": "a428d72d-886d-4060-8c19-e787bd0fdcd1",
         "collapsed": false,
-        "requestMsgId": "a428d72d-886d-4060-8c19-e787bd0fdcd1",
-        "executionStartTime": 1633988333130,
-        "executionStopTime": 1633988333211
+        "requestMsgId": "6ed34a0e-341e-4616-a498-2f3b7ebe857e",
+        "executionStartTime": 1634146946545,
+        "executionStopTime": 1634146946838
       },
       "source": [
         "df[1]"
       ],
-      "execution_count": 20,
+      "execution_count": 21,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -934,16 +978,16 @@
             "text/plain": "(1, 5, 10, 100)"
           },
           "metadata": {
-            "bento_obj_id": "139691089846976"
+            "bento_obj_id": "139832115361808"
           },
-          "execution_count": 20
+          "execution_count": 21
         }
       ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "1ea05b0c-6b68-4896-8aae-332682acf1ca"
+        "originalKey": "ec6c39eb-b967-41d1-920e-04ed7cb82cb3"
       },
       "source": [
         "Selecting a slice keeps the type alive. Here we slice rows:\n",
@@ -953,16 +997,16 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "5b049bc4-a5c5-46c3-ac2e-d742ea303c47",
+        "originalKey": "edc4e2cb-87ed-4c57-915d-ae81951ad6db",
         "collapsed": false,
-        "requestMsgId": "edc4e2cb-87ed-4c57-915d-ae81951ad6db",
-        "executionStartTime": 1633988333221,
-        "executionStopTime": 1633988333228
+        "requestMsgId": "f198eb5c-6626-4dbc-a513-44a4534b7a7c",
+        "executionStartTime": 1634146946844,
+        "executionStopTime": 1634146946896
       },
       "source": [
         "df[2:6:2]"
       ],
-      "execution_count": 21,
+      "execution_count": 22,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -970,42 +1014,7 @@
             "text/plain": "  index    a    b    c    d\n-------  ---  ---  ---  ---\n      0    2    4    8  101\n      1    4    2    4  103\ndtype: Struct([Field('a', int64), Field('b', int64), Field('c', int64), Field('d', int64)]), count: 2, null_count: 0"
           },
           "metadata": {
-            "bento_obj_id": "139691090020528"
-          },
-          "execution_count": 21
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "originalKey": "d92f621c-7d21-46b7-adeb-f002da58305d"
-      },
-      "source": [
-        "But you can also slice columns. The below return all columns after and including 'c'."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "originalKey": "6a861bb3-957b-4d7c-919b-e14782a3afcd",
-        "collapsed": false,
-        "requestMsgId": "63b11653-9ab3-43c2-800b-3fa2de2367c7",
-        "executionStartTime": 1633988333303,
-        "executionStopTime": 1633988333310
-      },
-      "source": [
-        "df['c':]"
-      ],
-      "execution_count": 22,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": "  index    c     d\n-------  ---  ----\n      0   12    99\n      1   10   100\n      2    8   101\n      3    6   102\n      4    4   103\n      5    2   104\n      6    0   105\n      7  777  7777\n      8  888  8888\ndtype: Struct([Field('c', int64), Field('d', int64)]), count: 9, null_count: 0"
-          },
-          "metadata": {
-            "bento_obj_id": "139691090018800"
+            "bento_obj_id": "139832115418448"
           },
           "execution_count": 22
         }
@@ -1014,7 +1023,42 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "f560cc21-7d02-4997-99ca-2a53fd9dd1a4",
+        "originalKey": "3fb1ab56-d921-4601-a936-fb42008c4fbb"
+      },
+      "source": [
+        "But you can also slice columns. The below return all columns after and including 'c'."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "63b11653-9ab3-43c2-800b-3fa2de2367c7",
+        "collapsed": false,
+        "requestMsgId": "74e562f4-0c75-4453-93c0-1b206a9de830",
+        "executionStartTime": 1634146946931,
+        "executionStopTime": 1634146947071
+      },
+      "source": [
+        "df['c':]"
+      ],
+      "execution_count": 23,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  index    c     d\n-------  ---  ----\n      0   12    99\n      1   10   100\n      2    8   101\n      3    6   102\n      4    4   103\n      5    2   104\n      6    0   105\n      7  777  7777\n      8  888  8888\ndtype: Struct([Field('c', int64), Field('d', int64)]), count: 9, null_count: 0"
+          },
+          "metadata": {
+            "bento_obj_id": "139832115497856"
+          },
+          "execution_count": 23
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "originalKey": "39596721-fafa-4afe-8e30-adebc69d41e7",
         "showInput": false,
         "code_folding": [],
         "hidden_ranges": []
@@ -1026,7 +1070,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "a61b241e-7788-405e-941f-0d556d9732af"
+        "originalKey": "baacc363-e121-4fcf-a9c8-23d966f12fa0"
       },
       "source": [
         "## Selection by Condition\n",
@@ -1039,16 +1083,16 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "4c2a91af-3fb0-49f5-aa53-43355c2cc87f",
+        "originalKey": "ad9bfa3b-d6c8-45d6-864f-6b3954869f3a",
         "collapsed": false,
-        "requestMsgId": "ad9bfa3b-d6c8-45d6-864f-6b3954869f3a",
-        "executionStartTime": 1633988333319,
-        "executionStopTime": 1633988333393
+        "requestMsgId": "a4566ece-18c3-49da-a152-7a3d5be2b729",
+        "executionStartTime": 1634146947180,
+        "executionStopTime": 1634146947213
       },
       "source": [
         "df[[True] + [False] * (len(df)-1)]"
       ],
-      "execution_count": 23,
+      "execution_count": 24,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -1056,43 +1100,7 @@
             "text/plain": "  index    a    b    c    d\n-------  ---  ---  ---  ---\n      0    0    6   12   99\ndtype: Struct([Field('a', int64), Field('b', int64), Field('c', int64), Field('d', int64)]), count: 1, null_count: 0"
           },
           "metadata": {
-            "bento_obj_id": "139691089537824"
-          },
-          "execution_count": 23
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "originalKey": "8bec517a-9185-4d03-8f5b-3fc0af9a88c8"
-      },
-      "source": [
-        "Conditional expressions over vectors return boolean vectors. Conditionals are thus the usual way to write filters. "
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "originalKey": "6117294f-8e12-4082-b891-9f56b0130d90",
-        "collapsed": false,
-        "requestMsgId": "6496730a-c016-49a4-a436-7be4791e053b",
-        "executionStartTime": 1633988333456,
-        "executionStopTime": 1633988333464
-      },
-      "source": [
-        "b = df['a'] > 4\n",
-        "df[b]"
-      ],
-      "execution_count": 24,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": "  index    a    b    c     d\n-------  ---  ---  ---  ----\n      0    5    1    2   104\n      1    6    0    0   105\n      2    7   77  777  7777\n      3    8   88  888  8888\ndtype: Struct([Field('a', int64), Field('b', int64), Field('c', int64), Field('d', int64)]), count: 4, null_count: 0"
-          },
-          "metadata": {
-            "bento_obj_id": "139691089686688"
+            "bento_obj_id": "139832115417632"
           },
           "execution_count": 24
         }
@@ -1101,7 +1109,43 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "80dd74cf-031d-40f1-9862-795b5dc31223"
+        "originalKey": "e4895c9f-3555-4c97-85f2-246f874055fb"
+      },
+      "source": [
+        "Conditional expressions over vectors return boolean vectors. Conditionals are thus the usual way to write filters. "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "6496730a-c016-49a4-a436-7be4791e053b",
+        "collapsed": false,
+        "requestMsgId": "86dd71f3-b280-44f6-823b-0c22e556828f",
+        "executionStartTime": 1634146947469,
+        "executionStopTime": 1634146947503
+      },
+      "source": [
+        "b = df['a'] > 4\n",
+        "df[b]"
+      ],
+      "execution_count": 25,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  index    a    b    c     d\n-------  ---  ---  ---  ----\n      0    5    1    2   104\n      1    6    0    0   105\n      2    7   77  777  7777\n      3    8   88  888  8888\ndtype: Struct([Field('a', int64), Field('b', int64), Field('c', int64), Field('d', int64)]), count: 4, null_count: 0"
+          },
+          "metadata": {
+            "bento_obj_id": "139832116065376"
+          },
+          "execution_count": 25
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "originalKey": "f4dc2c36-5a24-42a5-b960-612d5ded52a6"
       },
       "source": [
         "Torcharrow supports all the usual predicates, like <,==,!=>,>=,<= as well as _in_. The later is denoted by `isin`\n",
@@ -1111,16 +1155,16 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "35960d05-d085-4a7a-8090-ab5647afe6b0",
+        "originalKey": "04e901c7-eb60-47ba-9b01-5b69481f4177",
         "collapsed": false,
-        "requestMsgId": "04e901c7-eb60-47ba-9b01-5b69481f4177",
-        "executionStartTime": 1633988333545,
-        "executionStopTime": 1633988333558
+        "requestMsgId": "42a02c2c-72df-47c3-b69d-9ed0a2b110ca",
+        "executionStartTime": 1634146947507,
+        "executionStopTime": 1634146947514
       },
       "source": [
         "df[df['a'].isin([5])]"
       ],
-      "execution_count": 25,
+      "execution_count": 26,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -1128,16 +1172,16 @@
             "text/plain": "  index    a    b    c    d\n-------  ---  ---  ---  ---\n      0    5    1    2  104\ndtype: Struct([Field('a', int64), Field('b', int64), Field('c', int64), Field('d', int64)]), count: 1, null_count: 0"
           },
           "metadata": {
-            "bento_obj_id": "139691322367472"
+            "bento_obj_id": "139832116065472"
           },
-          "execution_count": 25
+          "execution_count": 26
         }
       ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "443f67e4-59cd-407b-ac68-11d5ab336d8c"
+        "originalKey": "faa2b1cd-01cc-4a8c-ae07-f1ba34417eb5"
       },
       "source": [
         "## Missing data\n",
@@ -1147,60 +1191,25 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "7ab6cd8d-f29a-4534-998a-9140f4f0b561",
+        "originalKey": "382b48a2-25a4-4f60-a0f0-4a156fd5a8fd",
         "collapsed": false,
-        "requestMsgId": "382b48a2-25a4-4f60-a0f0-4a156fd5a8fd",
-        "executionStartTime": 1633988333560,
-        "executionStopTime": 1633988333632
+        "requestMsgId": "00b4bb82-9b3b-42b0-94af-ae0aa6ff8851",
+        "executionStartTime": 1634146947522,
+        "executionStopTime": 1634146947576
       },
       "source": [
         "t = s.fillna(999)\n",
         "t"
-      ],
-      "execution_count": 26,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": "0    1\n1    2\n2  999\n3    4\ndtype: int64, length: 4, null_count: 0"
-          },
-          "metadata": {
-            "bento_obj_id": "139691089938320"
-          },
-          "execution_count": 26
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "originalKey": "34d3f52c-9635-485a-afdd-2d6056fa95da"
-      },
-      "source": [
-        "Alternatively data that has null data can be dropped:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "originalKey": "3e218b0c-52b6-4649-8536-8082d3f9b88a",
-        "collapsed": false,
-        "requestMsgId": "745a2164-ce40-48cf-8b94-d9a0bc93a39f",
-        "executionStartTime": 1633988333696,
-        "executionStopTime": 1633988333704
-      },
-      "source": [
-        "s.dropna()"
       ],
       "execution_count": 27,
       "outputs": [
         {
           "output_type": "execute_result",
           "data": {
-            "text/plain": "0  1\n1  2\n2  4\ndtype: int64, length: 3, null_count: 0"
+            "text/plain": "0    1\n1    2\n2  999\n3    4\ndtype: Int64(nullable=True), length: 4, null_count: 0"
           },
           "metadata": {
-            "bento_obj_id": "139691089937840"
+            "bento_obj_id": "139832115444080"
           },
           "execution_count": 27
         }
@@ -1209,7 +1218,42 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "a1812ef9-65ec-4131-a60a-bebc9742f0ee"
+        "originalKey": "974e03ce-59f5-48cd-80e8-e2f5fcb629c9"
+      },
+      "source": [
+        "Alternatively data that has null data can be dropped:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "745a2164-ce40-48cf-8b94-d9a0bc93a39f",
+        "collapsed": false,
+        "requestMsgId": "7fc159fb-cec0-4b83-987a-0b45ca0a7f4b",
+        "executionStartTime": 1634146947581,
+        "executionStopTime": 1634146947680
+      },
+      "source": [
+        "s.dropna()"
+      ],
+      "execution_count": 28,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "0  1\n1  2\n2  4\ndtype: Int64(nullable=True), length: 3, null_count: 0"
+          },
+          "metadata": {
+            "bento_obj_id": "139832152344176"
+          },
+          "execution_count": 28
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "originalKey": "189a33bd-547b-40a1-8265-e436295c2ee0"
       },
       "source": [
         "## Operators\n",
@@ -1223,11 +1267,11 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "c306e2f1-eda0-4028-9554-a23fad1a3c14",
+        "originalKey": "2d2faefb-c239-43f8-b250-db741e4369bf",
         "collapsed": false,
-        "requestMsgId": "2d2faefb-c239-43f8-b250-db741e4369bf",
-        "executionStartTime": 1633988333774,
-        "executionStopTime": 1633988333789
+        "requestMsgId": "66932ea3-76c8-42b3-86b9-c014b4da7919",
+        "executionStartTime": 1634146947716,
+        "executionStopTime": 1634146947757
       },
       "source": [
         "u = ta.Column(list(range(5)))\n",
@@ -1235,7 +1279,7 @@
         "w = v+1\n",
         "v*w"
       ],
-      "execution_count": 28,
+      "execution_count": 29,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -1243,20 +1287,20 @@
             "text/plain": "0   0\n1   0\n2   2\n3   6\n4  12\ndtype: int64, length: 5, null_count: 0"
           },
           "metadata": {
-            "bento_obj_id": "139691332408896"
+            "bento_obj_id": "139832115550960"
           },
-          "execution_count": 28
+          "execution_count": 29
         }
       ]
     },
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "f360a49e-69fc-4aee-b44f-1f3c5cdf228e",
+        "originalKey": "443247e5-d8de-43cf-bd08-7f15435d6b24",
         "collapsed": false,
-        "requestMsgId": "443247e5-d8de-43cf-bd08-7f15435d6b24",
-        "executionStartTime": 1633988333793,
-        "executionStopTime": 1633988333862
+        "requestMsgId": "673310f4-cc3f-4884-b9df-0f0adfd43fd4",
+        "executionStartTime": 1634146947852,
+        "executionStopTime": 1634146947971
       },
       "source": [
         "uv = ta.DataFrame({\"a\": u, \"b\": v})\n",
@@ -1264,24 +1308,24 @@
         "(uv == uu)\n",
         ""
       ],
-      "execution_count": 29,
+      "execution_count": 30,
       "outputs": [
         {
           "output_type": "execute_result",
           "data": {
-            "text/plain": "  index    a    b\n-------  ---  ---\n      0    1    1\n      1    1    0\n      2    1    0\n      3    1    0\n      4    1    0\ndtype: Struct([Field('a', boolean), Field('b', boolean)]), count: 5, null_count: 0"
+            "text/plain": "  index  a     b\n-------  ----  -----\n      0  True  True\n      1  True  False\n      2  True  False\n      3  True  False\n      4  True  False\ndtype: Struct([Field('a', boolean), Field('b', boolean)]), count: 5, null_count: 0"
           },
           "metadata": {
-            "bento_obj_id": "139691090197184"
+            "bento_obj_id": "139832116066720"
           },
-          "execution_count": 29
+          "execution_count": 30
         }
       ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "0bb4874d-5fb3-4e5d-b9dd-21e9b5fee7d0"
+        "originalKey": "f25722fd-786d-4542-8e45-555609fc9c87"
       },
       "source": [
         "## Null strictness\n",
@@ -1292,11 +1336,11 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "584b249b-fc70-408e-a1a4-75fd1ab52175",
+        "originalKey": "540a4fc0-fa9e-4002-997d-8390d3eabab4",
         "collapsed": false,
-        "requestMsgId": "540a4fc0-fa9e-4002-997d-8390d3eabab4",
-        "executionStartTime": 1633988333870,
-        "executionStopTime": 1633988333956
+        "requestMsgId": "656097b2-5900-48aa-bcf4-6b9a274a5bb7",
+        "executionStartTime": 1634146948023,
+        "executionStopTime": 1634146948178
       },
       "source": [
         "u = ta.Column([1, None, 3])\n",
@@ -1304,7 +1348,7 @@
         "u + v\n",
         ""
       ],
-      "execution_count": 30,
+      "execution_count": 31,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -1312,16 +1356,16 @@
             "text/plain": "0  12\n1  None\n2  None\ndtype: Int64(nullable=True), length: 3, null_count: 2"
           },
           "metadata": {
-            "bento_obj_id": "139691089688992"
+            "bento_obj_id": "139832115562576"
           },
-          "execution_count": 30
+          "execution_count": 31
         }
       ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "34afb2e5-3371-4f1a-8bfd-4298b06e7cc1",
+        "originalKey": "64f45ae5-7dee-440f-af71-7657e42889fe",
         "showInput": false,
         "code_folding": [],
         "hidden_ranges": []
@@ -1333,7 +1377,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "f881f3a1-695e-49f2-a4c4-f2d450b0b8f8"
+        "originalKey": "cb1f8bba-a750-4153-b195-ff9a2ce36f88"
       },
       "source": [
         "## Numerical columns and descriptive statistics\n",
@@ -1344,50 +1388,14 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "35e23de6-bdcc-4a13-98e8-20c63a1c9ec9",
+        "originalKey": "504f6958-4550-4c4a-b664-49630248231f",
         "collapsed": false,
-        "requestMsgId": "504f6958-4550-4c4a-b664-49630248231f",
-        "executionStartTime": 1633988334021,
-        "executionStopTime": 1633988334029
+        "requestMsgId": "7cb1a1d3-730a-4888-9919-2c11a833f115",
+        "executionStartTime": 1634146948239,
+        "executionStopTime": 1634146948345
       },
       "source": [
         "(t.min(), t.max(), t.sum(), t.mean())\n",
-        ""
-      ],
-      "execution_count": 31,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": "(1, 999, 1006, 251.5)"
-          },
-          "metadata": {
-            "bento_obj_id": "139691322527888"
-          },
-          "execution_count": 31
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "originalKey": "853e9d14-bf85-41e3-aa58-dde0fd40e257"
-      },
-      "source": [
-        "The `describe` method puts this nicely together: "
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "originalKey": "c54d0d1c-33ec-4ed2-b73f-1357ab235bf7",
-        "collapsed": false,
-        "requestMsgId": "310d6b29-8035-4d59-bfd0-d66fcadd1968",
-        "executionStartTime": 1633988334038,
-        "executionStopTime": 1633988334106
-      },
-      "source": [
-        "t.describe()\n",
         ""
       ],
       "execution_count": 32,
@@ -1395,10 +1403,10 @@
         {
           "output_type": "execute_result",
           "data": {
-            "text/plain": "  index  statistic      value\n-------  -----------  -------\n      0  count          4\n      1  mean         251.5\n      2  std          498.335\n      3  min            1\n      4  25%            1.5\n      5  50%            3\n      6  75%          501.5\n      7  max          999\ndtype: Struct([Field('statistic', string), Field('value', float64)]), count: 8, null_count: 0"
+            "text/plain": "(1, 999, 1006, 251.5)"
           },
           "metadata": {
-            "bento_obj_id": "139691090022256"
+            "bento_obj_id": "139832115329920"
           },
           "execution_count": 32
         }
@@ -1407,7 +1415,43 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "a32e5feb-1b97-40ba-9f9b-55c9e1ac30ff"
+        "originalKey": "a27f173e-e994-466f-b738-3653c0a1cfc7"
+      },
+      "source": [
+        "The `describe` method puts this nicely together: "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "310d6b29-8035-4d59-bfd0-d66fcadd1968",
+        "collapsed": false,
+        "requestMsgId": "13122fc4-95a0-4982-8892-1e8ca1317eb5",
+        "executionStartTime": 1634146948558,
+        "executionStopTime": 1634146948567
+      },
+      "source": [
+        "t.describe()\n",
+        ""
+      ],
+      "execution_count": 33,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "  index  statistic      value\n-------  -----------  -------\n      0  count          4\n      1  mean         251.5\n      2  std          498.335\n      3  min            1\n      4  25%            1.75\n      5  50%            3\n      6  75%          252.75\n      7  max          999\ndtype: Struct([Field('statistic', string), Field('value', float64)]), count: 8, null_count: 0"
+          },
+          "metadata": {
+            "bento_obj_id": "139832115472464"
+          },
+          "execution_count": 33
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "originalKey": "b155644c-9197-49c6-8147-2e8dc483cb00"
       },
       "source": [
         "Sum, prod, min and max are also available as accumulating operators called `cumsum`, `cumprod`, etc. \n",
@@ -1418,66 +1462,34 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "f7394df5-2c85-4ee1-b1fd-1511328f6f1e"
+        "originalKey": "a0380093-50de-419b-9a76-2a149f7420dd",
+        "showInput": false,
+        "code_folding": [],
+        "hidden_ranges": []
       },
       "source": [
         "## String, list and map methods\n",
         "Torcharrow provides all of Python's string, list and map processing methods, just lifted to work over columns. Like in Pandas they are all accessible via the `str`, `list` and `map` property, respectively.\n",
         "\n",
         "### Strings\n",
-        "Let's capitalize a column of strings.\n",
+        "Let's convert a Column of strings to upper case. \n",
         ""
       ]
     },
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "720ca841-ca65-4a9c-8f8f-0b0acdcf5579",
+        "originalKey": "57a885f3-7bd5-45e8-b496-78a1db103a05",
         "collapsed": false,
-        "requestMsgId": "57a885f3-7bd5-45e8-b496-78a1db103a05",
-        "executionStartTime": 1633988334114,
-        "executionStopTime": 1633988334180
+        "requestMsgId": "5476c9a8-3c6c-43c1-aeb2-a9b6f7d47c10",
+        "executionStartTime": 1634146948679,
+        "executionStopTime": 1634146948734,
+        "code_folding": [],
+        "hidden_ranges": []
       },
       "source": [
         "s = ta.Column([\"what a wonderful world!\", \"really?\"])\n",
-        "s.str.capitalize()\n",
-        ""
-      ],
-      "execution_count": 33,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": "0  'What a wonderful world!'\n1  'Really?'\ndtype: string, length: 2, null_count: 0"
-          },
-          "metadata": {
-            "bento_obj_id": "139691089937408"
-          },
-          "execution_count": 33
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "originalKey": "4b856c86-b8eb-4525-8a8f-f347a39e0d84"
-      },
-      "source": [
-        "Split is more involved. We have to decide whether a string gets split into a list of strings or into spread over a set of columns. So split gets an extra parameter called expand: the default is that expand=False, in which case split return a list column, if expand=True split return a list of columns as a dataframe:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "originalKey": "0c47506e-8c43-4350-914a-c57db5a92d77",
-        "collapsed": false,
-        "requestMsgId": "574dbe5c-f1e1-4a29-b9fe-fa9d50eab7dc",
-        "executionStartTime": 1633988334188,
-        "executionStopTime": 1633988334250
-      },
-      "source": [
-        "ss = s.str.split(sep=\" \")\n",
-        "ss\n",
+        "s.str.upper()\n",
         ""
       ],
       "execution_count": 34,
@@ -1485,27 +1497,40 @@
         {
           "output_type": "execute_result",
           "data": {
-            "text/plain": "0  ['what', 'a', 'wonderful', 'world!']\n1  ['really?']\ndtype: List(string), length: 2, null_count: 0"
+            "text/plain": "0  'WHAT A WONDERFUL WORLD!'\n1  'REALLY?'\ndtype: string, length: 2, null_count: 0, device: cpu"
           },
           "metadata": {
-            "bento_obj_id": "139691322367088"
+            "bento_obj_id": "139832115548944"
           },
           "execution_count": 34
         }
       ]
     },
     {
-      "cell_type": "code",
+      "cell_type": "markdown",
       "metadata": {
-        "originalKey": "61ed600b-9e38-408b-a744-600081644519",
-        "collapsed": false,
-        "requestMsgId": "5d4e6962-fa10-4d84-92e7-dc30580f2094",
-        "executionStartTime": 1633988334299,
-        "executionStopTime": 1633988334306
+        "originalKey": "bde0c394-a8cb-46bc-8f73-307c2787b314",
+        "showInput": false,
+        "code_folding": [],
+        "hidden_ranges": []
       },
       "source": [
-        "cs = s.str.split(sep=\" \", expand=True, maxsplit=2)\n",
-        "cs\n",
+        "We can also split each string to a list of strings with the given delimiter.\n",
+        ""
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "574dbe5c-f1e1-4a29-b9fe-fa9d50eab7dc",
+        "collapsed": false,
+        "requestMsgId": "62d3b023-e64b-4a2c-b599-3917410f3da8",
+        "executionStartTime": 1634146948783,
+        "executionStopTime": 1634146948979
+      },
+      "source": [
+        "ss = s.str.split(sep=\" \")\n",
+        "ss\n",
         ""
       ],
       "execution_count": 35,
@@ -1513,10 +1538,10 @@
         {
           "output_type": "execute_result",
           "data": {
-            "text/plain": "  index  0        1    2\n-------  -------  ---  ----------------\n      0  what     a    wonderful world!\n      1  really?\ndtype: Struct([Field('0', String(nullable=True)), Field('1', String(nullable=True)), Field('2', String(nullable=True))]), count: 2, null_count: 0"
+            "text/plain": "0  ['WHAT', 'A', 'WONDERFUL', 'WORLD!']\n1  ['really?']\ndtype: List(string), length: 2, null_count: 0"
           },
           "metadata": {
-            "bento_obj_id": "139691089688560"
+            "bento_obj_id": "139832115454592"
           },
           "execution_count": 35
         }
@@ -1525,7 +1550,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "f513aed1-7562-4c0c-8480-927d091171e8"
+        "originalKey": "c8f8f9f2-4fa7-4ed6-ae82-bdca98cca212"
       },
       "source": [
         "### Lists\n",
@@ -1539,11 +1564,11 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "e1ed5360-1fc0-4002-9fd8-d18a739f45ba",
+        "originalKey": "a289c6c5-6989-43df-b351-1727bd5fb36f",
         "collapsed": false,
-        "requestMsgId": "a289c6c5-6989-43df-b351-1727bd5fb36f",
-        "executionStartTime": 1633988334375,
-        "executionStopTime": 1633988334405
+        "requestMsgId": "f396d770-2718-4fb3-b7d2-49560db2b1c7",
+        "executionStartTime": 1634146949058,
+        "executionStopTime": 1634146949208
       },
       "source": [
         "ss.list.join(sep=\"-\")\n",
@@ -1554,10 +1579,10 @@
         {
           "output_type": "execute_result",
           "data": {
-            "text/plain": "0  'what-a-wonderful-world!'\n1  'really?'\ndtype: string, length: 2, null_count: 0"
+            "text/plain": "0  'WHAT-A-WONDERFUL-WORLD!'\n1  'really?'\ndtype: string, length: 2, null_count: 0, device: cpu"
           },
           "metadata": {
-            "bento_obj_id": "139691089576240"
+            "bento_obj_id": "139832115471408"
           },
           "execution_count": 36
         }
@@ -1566,7 +1591,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "f99c3d87-0db8-4ace-a3d6-9b07c36cb2d1",
+        "originalKey": "3af3113c-5187-4723-a872-db888198654f",
         "showInput": false,
         "code_folding": [],
         "hidden_ranges": []
@@ -1582,11 +1607,11 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "f67591a7-3a1c-458c-98ba-5d4ebf1f80f8",
+        "originalKey": "de368152-9a3e-4b7c-95a7-a441fdd89485",
         "collapsed": false,
-        "requestMsgId": "de368152-9a3e-4b7c-95a7-a441fdd89485",
-        "executionStartTime": 1633988334408,
-        "executionStopTime": 1633988334506,
+        "requestMsgId": "6c901ed8-160a-4eee-a203-ed8036423088",
+        "executionStartTime": 1634146949217,
+        "executionStopTime": 1634146949274,
         "code_folding": [],
         "hidden_ranges": []
       },
@@ -1602,7 +1627,7 @@
             "text/plain": "0  ['helsinki', 'moscow']\n1  ['algiers', 'kinshasa']\ndtype: List(string), length: 2, null_count: 0"
           },
           "metadata": {
-            "bento_obj_id": "139691332410096"
+            "bento_obj_id": "139832115550432"
           },
           "execution_count": 37
         }
@@ -1611,7 +1636,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "a95314d4-cec7-425f-afc9-253f29786966",
+        "originalKey": "33cd7f02-2c0f-4bae-a8a3-a1cb796a66b0",
         "showInput": false,
         "code_folding": [],
         "hidden_ranges": []
@@ -1628,11 +1653,11 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "1431a9b4-a662-4d67-b4b5-37d1ae95de19",
+        "originalKey": "107c808a-08e8-4f98-b1b0-45d6294a8b75",
         "collapsed": false,
-        "requestMsgId": "107c808a-08e8-4f98-b1b0-45d6294a8b75",
-        "executionStartTime": 1633988334515,
-        "executionStopTime": 1633988334560
+        "requestMsgId": "c76b5e6b-e441-4c34-b12d-e02a15bd631f",
+        "executionStartTime": 1634146949314,
+        "executionStopTime": 1634146949374
       },
       "source": [
         "xf = ta.DataFrame({\"A\": [\"a\", \"b\", \"a\", \"b\"], \"B\": [1, 2, 3, 4], \"C\": [10, 11, 12, 13]})\n",
@@ -1648,7 +1673,7 @@
             "text/plain": "  index  A      B    C\n-------  ---  ---  ---\n      0  a      3   12\n      1  b      4   13\ndtype: Struct([Field('A', string), Field('B', int64), Field('C', int64)]), count: 2, null_count: 0"
           },
           "metadata": {
-            "bento_obj_id": "139691089619264"
+            "bento_obj_id": "139832116066912"
           },
           "execution_count": 38
         }
@@ -1657,7 +1682,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "0b3978da-ebd6-41bd-8f6e-0cbc644900a1"
+        "originalKey": "e34fa4b9-0432-4384-969b-d8458da2d02e"
       },
       "source": [
         "Note that in `xf.where` the predicate `xf['B']>2` refers to self, i.e. `xf`. To access self in an expression TorchArrow introduces the special name `me`. That is, we can also write:\n",
@@ -1667,11 +1692,11 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "596257de-ba4f-4e36-92e7-7d683e713952",
+        "originalKey": "39e9810c-f236-473e-9aa9-22faf539062f",
         "collapsed": false,
-        "requestMsgId": "39e9810c-f236-473e-9aa9-22faf539062f",
-        "executionStartTime": 1633988334616,
-        "executionStopTime": 1633988334634
+        "requestMsgId": "84b00491-fe7c-4eb4-a168-d4a85824aa8c",
+        "executionStartTime": 1634146949568,
+        "executionStopTime": 1634146949611
       },
       "source": [
         "from torcharrow import me\n",
@@ -1688,7 +1713,7 @@
             "text/plain": "  index  A      B    C\n-------  ---  ---  ---\n      0  a      3   12\n      1  b      4   13\ndtype: Struct([Field('A', string), Field('B', int64), Field('C', int64)]), count: 2, null_count: 0"
           },
           "metadata": {
-            "bento_obj_id": "139691089620512"
+            "bento_obj_id": "139832115417728"
           },
           "execution_count": 39
         }
@@ -1697,7 +1722,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "d8e4aa12-ef6a-4083-83f9-bbdb5d36ba45"
+        "originalKey": "8da066f1-f3ce-42de-950e-ad0f20f7ecaa"
       },
       "source": [
         "### Select\n",
@@ -1709,13 +1734,13 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "3c7cde88-943f-4095-b131-366dfe17a995",
+        "originalKey": "02412b68-43dd-4d8f-923d-12a0de572f8e",
         "code_folding": [],
         "hidden_ranges": [],
         "collapsed": false,
-        "requestMsgId": "02412b68-43dd-4d8f-923d-12a0de572f8e",
-        "executionStartTime": 1633988334685,
-        "executionStopTime": 1633988334705
+        "requestMsgId": "d98474a8-d115-4a90-9b1e-f29b8bdd680b",
+        "executionStartTime": 1634146949620,
+        "executionStopTime": 1634146949634
       },
       "source": [
         "xf.select(*xf.columns, D=me[\"B\"] + me[\"C\"])\n",
@@ -1729,7 +1754,7 @@
             "text/plain": "  index  A      B    C    D\n-------  ---  ---  ---  ---\n      0  a      1   10   11\n      1  b      2   11   13\n      2  a      3   12   15\n      3  b      4   13   17\ndtype: Struct([Field('A', string), Field('B', int64), Field('C', int64), Field('D', int64)]), count: 4, null_count: 0"
           },
           "metadata": {
-            "bento_obj_id": "139691089597440"
+            "bento_obj_id": "139832115294992"
           },
           "execution_count": 40
         }
@@ -1738,7 +1763,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "e89a5432-5d10-40ec-9987-63b8399ba25b"
+        "originalKey": "1f7da523-4418-467a-9e90-fc395b7c1385"
       },
       "source": [
         "The short form of `*xf.columns` is '\\*', so `xf.select('*', D=me['B']+me['C'])` does the same."
@@ -1747,7 +1772,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "56bb0cc8-5e35-4ff6-b3e2-8256759940c3",
+        "originalKey": "6f3773d8-4220-4beb-9321-bc423c74e5c5",
         "showInput": false,
         "code_folding": [],
         "hidden_ranges": []
@@ -1762,7 +1787,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "742b4d90-a2a6-49bc-ac66-274a4788f024",
+        "originalKey": "0538bb2b-7847-47f2-a441-ac2e1abac7e5",
         "showInput": false,
         "code_folding": [],
         "hidden_ranges": []
@@ -1783,11 +1808,11 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "4e209a20-1d22-408a-9912-bfe7c16194fc",
+        "originalKey": "8437438f-b5a8-4ee1-b58b-0acb697551db",
         "collapsed": false,
-        "requestMsgId": "8437438f-b5a8-4ee1-b58b-0acb697551db",
-        "executionStartTime": 1633988334713,
-        "executionStopTime": 1633988334823
+        "requestMsgId": "55705745-2e2b-4d2e-b81d-5b824ccaee40",
+        "executionStartTime": 1634146949637,
+        "executionStopTime": 1634146949652
       },
       "source": [
         "ta.Column([1, 2, None, 4]).map({1: 111})\n",
@@ -1801,7 +1826,7 @@
             "text/plain": "0  111\n1  None\n2  None\n3  None\ndtype: Int64(nullable=True), length: 4, null_count: 3"
           },
           "metadata": {
-            "bento_obj_id": "139691089598784"
+            "bento_obj_id": "139832115418304"
           },
           "execution_count": 41
         }
@@ -1810,7 +1835,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "caa8bf1c-0f58-4805-bcff-c61662acf8d4"
+        "originalKey": "f657d9fe-df05-435a-89f7-79912203b3ac"
       },
       "source": [
         "If the mapping is a defaultdict, all values will be mapped as described by the default dict."
@@ -1819,13 +1844,13 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "4eb3a3e9-1931-4cb6-940c-7f35308f4d31",
+        "originalKey": "58664bc7-46c5-4841-8194-dd0605bad436",
         "code_folding": [],
         "hidden_ranges": [],
         "collapsed": false,
-        "requestMsgId": "58664bc7-46c5-4841-8194-dd0605bad436",
-        "executionStartTime": 1633988334833,
-        "executionStopTime": 1633988334884
+        "requestMsgId": "20f887e3-9167-4a6d-b63f-c2baa21e336c",
+        "executionStartTime": 1634146949709,
+        "executionStopTime": 1634146949872
       },
       "source": [
         "from collections import defaultdict\n",
@@ -1840,7 +1865,7 @@
             "text/plain": "0  111\n1   -1\n2   -1\n3   -1\ndtype: Int64(nullable=True), length: 4, null_count: 0"
           },
           "metadata": {
-            "bento_obj_id": "139691089598352"
+            "bento_obj_id": "139832115473568"
           },
           "execution_count": 42
         }
@@ -1849,7 +1874,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "4659e6bd-3f96-4da8-ac5a-65dc69e3597f",
+        "originalKey": "12ce419b-e4f6-42d5-9e71-c43fe5da6ebe",
         "showInput": false,
         "code_folding": [],
         "hidden_ranges": []
@@ -1861,13 +1886,13 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "6240d2f6-4f99-4abc-84a3-e6368de73241",
+        "originalKey": "857a2973-43d3-4233-85a8-4baed5989c76",
         "code_folding": [],
         "hidden_ranges": [],
         "collapsed": false,
-        "requestMsgId": "857a2973-43d3-4233-85a8-4baed5989c76",
-        "executionStartTime": 1633988334933,
-        "executionStopTime": 1633988334947
+        "requestMsgId": "0a31949a-a6f9-4e26-a09d-c30cebb1b3f6",
+        "executionStartTime": 1634146949904,
+        "executionStopTime": 1634146949920
       },
       "source": [
         "def add_ten(num):\n",
@@ -1884,7 +1909,7 @@
             "text/plain": "0  11\n1  12\n2  None\n3  14\ndtype: Int64(nullable=True), length: 4, null_count: 1"
           },
           "metadata": {
-            "bento_obj_id": "139691089579312"
+            "bento_obj_id": "139832115262800"
           },
           "execution_count": 43
         }
@@ -1893,7 +1918,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "f54c5108-4bd7-442c-ba78-4dfefb602283",
+        "originalKey": "d688b34c-7b7b-4b93-bf2f-fe379bd3db89",
         "showInput": false,
         "code_folding": [],
         "hidden_ranges": []
@@ -1905,11 +1930,11 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "03a83f8d-2deb-4f46-ad66-c3c9fa4f288c",
+        "originalKey": "2c657ba6-07d3-4d43-8680-b331de040980",
         "collapsed": false,
-        "requestMsgId": "2c657ba6-07d3-4d43-8680-b331de040980",
-        "executionStartTime": 1633988334950,
-        "executionStopTime": 1633988335010
+        "requestMsgId": "14ae8536-781c-4b78-98c3-15a06e813abe",
+        "executionStartTime": 1634146949923,
+        "executionStopTime": 1634146949982
       },
       "source": [
         "def add_ten_or_0(num):\n",
@@ -1927,7 +1952,7 @@
             "text/plain": "0  11\n1  12\n2   0\n3  14\ndtype: Int64(nullable=True), length: 4, null_count: 0"
           },
           "metadata": {
-            "bento_obj_id": "139691089620224"
+            "bento_obj_id": "139832115261648"
           },
           "execution_count": 44
         }
@@ -1936,7 +1961,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "f68be658-91fd-4f8a-a227-f16556e6653e",
+        "originalKey": "ef75b768-0496-4140-b50c-f73650e02cac",
         "showInput": false
       },
       "source": [
@@ -1946,11 +1971,11 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "d465dc4d-5194-4792-bd52-e608031f2d36",
+        "originalKey": "43571ae6-0263-4f63-832a-bbc78a10766c",
         "collapsed": false,
-        "requestMsgId": "43571ae6-0263-4f63-832a-bbc78a10766c",
-        "executionStartTime": 1633988335054,
-        "executionStopTime": 1633988335103
+        "requestMsgId": "ccc8b4b6-0b30-4d4f-991d-dcedb51ea935",
+        "executionStartTime": 1634146949984,
+        "executionStopTime": 1634146950043
       },
       "source": [
         "ta.Column([1,2,3,4]).map(str, dtype=dt.string)"
@@ -1960,10 +1985,10 @@
         {
           "output_type": "execute_result",
           "data": {
-            "text/plain": "0  '1'\n1  '2'\n2  '3'\n3  '4'\ndtype: string, length: 4, null_count: 0"
+            "text/plain": "0  '1'\n1  '2'\n2  '3'\n3  '4'\ndtype: string, length: 4, null_count: 0, device: cpu"
           },
           "metadata": {
-            "bento_obj_id": "139691089598256"
+            "bento_obj_id": "139832115394400"
           },
           "execution_count": 45
         }
@@ -1972,7 +1997,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "35e01316-0e48-41d2-b944-7d5a56ac531a",
+        "originalKey": "e3ae4b80-95cb-4ad7-b347-0c18ab800c2c",
         "showInput": false,
         "customInput": null,
         "code_folding": [],
@@ -1985,15 +2010,15 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "0dc15824-2e42-425f-972d-44c7880d264f",
+        "originalKey": "281ab079-6778-42f0-aed5-e30058877226",
         "showInput": true,
         "customInput": null,
         "code_folding": [],
         "hidden_ranges": [],
         "collapsed": false,
-        "requestMsgId": "281ab079-6778-42f0-aed5-e30058877226",
-        "executionStartTime": 1633988335176,
-        "executionStopTime": 1633988335201
+        "requestMsgId": "b22479a2-0275-499b-a619-3728f1947ad7",
+        "executionStartTime": 1634146950095,
+        "executionStopTime": 1634146950217
       },
       "source": [
         "from typing import Optional\n",
@@ -2013,10 +2038,10 @@
         {
           "output_type": "execute_result",
           "data": {
-            "text/plain": "0  None\n1  '2'\n2  None\n3  '4'\ndtype: String(nullable=True), length: 4, null_count: 2"
+            "text/plain": "0  None\n1  '2'\n2  None\n3  '4'\ndtype: String(nullable=True), length: 4, null_count: 2, device: cpu"
           },
           "metadata": {
-            "bento_obj_id": "139691089577104"
+            "bento_obj_id": "139832115263184"
           },
           "execution_count": 46
         }
@@ -2025,7 +2050,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "0eb9d1ab-cf36-4310-bcdb-d560de27a932"
+        "originalKey": "300b9cbe-4784-4186-bdf2-60720c8a4c1c"
       },
       "source": [
         "**Map over Dataframes** Of course, `map` works over Dataframes, too. In this case the callable gets the whole row as a tuple. "
@@ -2034,11 +2059,11 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "2bbc619c-37cb-4dab-9c24-31e673d3d66a",
+        "originalKey": "eed4fc03-e0f5-4b71-a703-cefcf87fb194",
         "collapsed": false,
-        "requestMsgId": "eed4fc03-e0f5-4b71-a703-cefcf87fb194",
-        "executionStartTime": 1633988335209,
-        "executionStopTime": 1633988335254
+        "requestMsgId": "59bf68e3-af92-44b0-8f92-2d13b8d6943e",
+        "executionStartTime": 1634146950292,
+        "executionStopTime": 1634146950346
       },
       "source": [
         "def add_unary(tup):\n",
@@ -2056,7 +2081,7 @@
             "text/plain": "0  2\n1  4\n2  6\ndtype: int64, length: 3, null_count: 0"
           },
           "metadata": {
-            "bento_obj_id": "139691089765904"
+            "bento_obj_id": "139832115417440"
           },
           "execution_count": 47
         }
@@ -2065,7 +2090,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "9cf337cc-6bb3-494a-9c28-f35cfa4a8328",
+        "originalKey": "2024faea-2018-496c-9fe0-1411d5516407",
         "showInput": false,
         "code_folding": [],
         "hidden_ranges": []
@@ -2078,11 +2103,11 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "8a6550ba-83e5-4b53-91aa-304cdad5c13b",
+        "originalKey": "f8a6ada4-f661-4abf-bd63-f7d56b72921e",
         "collapsed": false,
-        "requestMsgId": "f8a6ada4-f661-4abf-bd63-f7d56b72921e",
-        "executionStartTime": 1633988335298,
-        "executionStopTime": 1633988335349
+        "requestMsgId": "5ccfdfd9-8615-4115-aa6b-50d0314a04de",
+        "executionStartTime": 1634146950349,
+        "executionStopTime": 1634146950401
       },
       "source": [
         "def add_binary(a, b):\n",
@@ -2102,7 +2127,7 @@
             "text/plain": "0  2\n1  4\n2  6\ndtype: int64, length: 3, null_count: 0"
           },
           "metadata": {
-            "bento_obj_id": "139691089774096"
+            "bento_obj_id": "139832115550528"
           },
           "execution_count": 48
         }
@@ -2111,7 +2136,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "c6c7c552-fa66-44cd-9b6c-d73d53bfeafb",
+        "originalKey": "7f6c7c13-c4ec-4b84-9cc7-8cd0f4fd1e98",
         "showInput": false,
         "code_folding": [],
         "hidden_ranges": []
@@ -2123,11 +2148,11 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "b3833f37-3531-4105-b654-5cd6ccea9157",
+        "originalKey": "2691361d-6b13-4c43-96bc-64bff55cde6a",
         "collapsed": false,
-        "requestMsgId": "2691361d-6b13-4c43-96bc-64bff55cde6a",
-        "executionStartTime": 1633988335405,
-        "executionStopTime": 1633988335412
+        "requestMsgId": "25604cfa-59fc-483d-96f6-641dc53daf37",
+        "executionStartTime": 1634146950604,
+        "executionStopTime": 1634146950694
       },
       "source": [
         "ta.DataFrame({\"a\": [17, 29, 30], \"b\": [3, 5, 11]}).map(\n",
@@ -2145,7 +2170,7 @@
             "text/plain": "  index    quotient    remainder\n-------  ----------  -----------\n      0           5            2\n      1           5            4\n      2           2            8\ndtype: Struct([Field('quotient', int64), Field('remainder', int64)]), count: 3, null_count: 0"
           },
           "metadata": {
-            "bento_obj_id": "139691089287824"
+            "bento_obj_id": "139832115497088"
           },
           "execution_count": 49
         }
@@ -2154,7 +2179,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "ed8915a6-e9c6-4c90-8554-0435bc71285f",
+        "originalKey": "ffa20549-250e-4bee-9a4f-441af3033138",
         "showInput": false,
         "code_folding": [],
         "hidden_ranges": []
@@ -2167,11 +2192,11 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "25447228-dad1-40de-b839-6a537d98c898",
+        "originalKey": "c469043f-62a4-422f-8063-ce556ca75a24",
         "collapsed": false,
-        "requestMsgId": "c469043f-62a4-422f-8063-ce556ca75a24",
-        "executionStartTime": 1633988335511,
-        "executionStopTime": 1633988335529
+        "requestMsgId": "528d5103-0271-450c-a2ff-81fe85f72743",
+        "executionStartTime": 1634146950743,
+        "executionStopTime": 1634146950775
       },
       "source": [
         "def fib(n):\n",
@@ -2209,7 +2234,7 @@
             "text/plain": "0  56\n1  57\n2  58\ndtype: int64, length: 3, null_count: 0"
           },
           "metadata": {
-            "bento_obj_id": "139691089285856"
+            "bento_obj_id": "139832115457664"
           },
           "execution_count": 50
         }
@@ -2218,7 +2243,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "633585eb-b00a-42fb-b07d-9e152d79d868"
+        "originalKey": "2d746692-bab3-466a-b705-8bd9609e2e96"
       },
       "source": [
         "TorchArrow requires that only global functions or methods on class instances can be used as user defined functions. Lambdas, which can can capture arbitrary state and are not inspectable, are not supported. "
@@ -2227,7 +2252,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "204583d2-957e-49eb-8648-fae4f6631508",
+        "originalKey": "ce08440a-8e9b-4862-9c7a-0bb50145fe40",
         "showInput": false,
         "code_folding": [],
         "hidden_ranges": []
@@ -2241,11 +2266,11 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "5f4992c1-5750-4bbb-93cf-4d8af57a9f24",
+        "originalKey": "4f11fb0e-c6b1-4462-9cb2-1aeb1fa6d1cf",
         "collapsed": false,
-        "requestMsgId": "4f11fb0e-c6b1-4462-9cb2-1aeb1fa6d1cf",
-        "executionStartTime": 1633988335536,
-        "executionStopTime": 1633988335613,
+        "requestMsgId": "55264f7b-883a-491d-9714-5ad492baffb4",
+        "executionStartTime": 1634146950843,
+        "executionStopTime": 1634146950885,
         "code_folding": [],
         "hidden_ranges": []
       },
@@ -2261,7 +2286,7 @@
             "text/plain": "0  1\n1  3\ndtype: int64, length: 2, null_count: 0"
           },
           "metadata": {
-            "bento_obj_id": "139691089767392"
+            "bento_obj_id": "139832115285344"
           },
           "execution_count": 51
         }
@@ -2270,7 +2295,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "ae7c9b6c-12c2-4d24-a832-050f6faa0824",
+        "originalKey": "da57ba4d-f308-4387-a630-a5dc371ff0ba",
         "showInput": false,
         "customInput": null,
         "code_folding": [],
@@ -2283,15 +2308,15 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "14fa8c22-28ab-4426-8dd2-4c7c512a1774",
+        "originalKey": "20556a49-36ed-42b4-b659-0f90620ff96b",
         "showInput": true,
         "customInput": null,
         "code_folding": [],
         "hidden_ranges": [],
         "collapsed": false,
-        "requestMsgId": "20556a49-36ed-42b4-b659-0f90620ff96b",
-        "executionStartTime": 1633988335639,
-        "executionStopTime": 1633988335678
+        "requestMsgId": "afe252e3-2652-47e3-8ddb-234840de43cb",
+        "executionStartTime": 1634146950888,
+        "executionStopTime": 1634146950983
       },
       "source": [
         "ta.Column([1, 2, 3, 4]).filter([True, False, True, False])\n",
@@ -2305,7 +2330,7 @@
             "text/plain": "0  1\n1  3\ndtype: int64, length: 2, null_count: 0"
           },
           "metadata": {
-            "bento_obj_id": "139691089772752"
+            "bento_obj_id": "139832115263904"
           },
           "execution_count": 52
         }
@@ -2314,7 +2339,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "8b2287d7-3bd2-4537-9b46-ac2719c9afae"
+        "originalKey": "7dbb1763-7ec6-47b4-bea8-c60aa1185930"
       },
       "source": [
         "If the predicate is an n-ary function, use the  `columns` argument as we have seen for `map`.  "
@@ -2323,7 +2348,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "45bbae99-d28d-4abf-aa72-6783a3ef8bbf"
+        "originalKey": "84e6b8c5-1710-4cc4-9a7d-d26a33085010"
       },
       "source": [
         "### Flatmap\n",
@@ -2334,11 +2359,11 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "dd033013-f74d-4e7f-b5f6-268045e3e2ae",
+        "originalKey": "aebd077f-4d6d-4f70-a5ca-74b0dd293671",
         "collapsed": false,
-        "requestMsgId": "aebd077f-4d6d-4f70-a5ca-74b0dd293671",
-        "executionStartTime": 1633988335735,
-        "executionStopTime": 1633988335747,
+        "requestMsgId": "4025d1e1-a1a7-4a93-9c27-02c5a58ddbca",
+        "executionStartTime": 1634146951001,
+        "executionStopTime": 1634146951061,
         "code_folding": [],
         "hidden_ranges": []
       },
@@ -2358,7 +2383,7 @@
             "text/plain": "0  ['I', 'am', 'fine', 'and', 'you']\n1  ['I', 'am', 'fine', 'and', 'you']\ndtype: List(string), length: 2, null_count: 0"
           },
           "metadata": {
-            "bento_obj_id": "139691089776400"
+            "bento_obj_id": "139832115282752"
           },
           "execution_count": 53
         }
@@ -2367,7 +2392,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "4a799910-d97a-4b15-9d38-cb17ccd04c82"
+        "originalKey": "986f3f7b-180d-4a04-831e-e3253ff785a2"
       },
       "source": [
         "`flatmap` has all the flexibility of `map`, i.e it can take the `ignore`, `dtype` and `column` arguments."
@@ -2376,7 +2401,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "2d9bb235-befb-4f54-bc71-e83e80b4cdbc"
+        "originalKey": "5f05b84b-6bc6-4c2f-886d-2de035e1ffe1"
       },
       "source": [
         "### Reduce\n",
@@ -2386,11 +2411,11 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "51106561-5cae-4981-80fa-576323a2cfc1",
+        "originalKey": "34d94c49-7288-40d0-b817-a88cc15be155",
         "collapsed": false,
-        "requestMsgId": "34d94c49-7288-40d0-b817-a88cc15be155",
-        "executionStartTime": 1633988335781,
-        "executionStopTime": 1633988335825
+        "requestMsgId": "d981d801-19d3-441c-93ac-0c17bec4b917",
+        "executionStartTime": 1634146951129,
+        "executionStopTime": 1634146951139
       },
       "source": [
         "import operator\n",
@@ -2407,7 +2432,7 @@
             "text/plain": "24"
           },
           "metadata": {
-            "bento_obj_id": "139691332416912"
+            "bento_obj_id": "139837951186592"
           },
           "execution_count": 54
         }
@@ -2416,7 +2441,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "f79135d9-2065-40c2-a7f0-3a41d3a0994b",
+        "originalKey": "08448f12-5eae-4fe4-816a-a54aa939bbd3",
         "showInput": false,
         "customInput": null,
         "code_folding": [],
@@ -2430,7 +2455,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "4700612a-3ab9-4228-bed0-e69b3614650d",
+        "originalKey": "463dc9a5-2789-4543-9c87-8f20eb678406",
         "showInput": false,
         "customInput": null,
         "code_folding": [],
@@ -2443,15 +2468,15 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "d982927b-9bc2-4153-8c0f-6d9f6787c63a",
+        "originalKey": "9d8c9a7a-3080-4d84-8c32-8e5aeffeea81",
         "showInput": true,
         "customInput": null,
         "code_folding": [],
         "hidden_ranges": [],
         "collapsed": false,
-        "requestMsgId": "9d8c9a7a-3080-4d84-8c32-8e5aeffeea81",
-        "executionStartTime": 1633988335875,
-        "executionStopTime": 1633988335927
+        "requestMsgId": "358cddd4-0a92-43dd-85ff-988fbc08ec5b",
+        "executionStartTime": 1634146951181,
+        "executionStopTime": 1634146951408
       },
       "source": [
         "from typing import List\n",
@@ -2472,7 +2497,7 @@
             "text/plain": "0  10\n1  20\n2  30\n3  40\ndtype: int64, length: 4, null_count: 0"
           },
           "metadata": {
-            "bento_obj_id": "139691089764560"
+            "bento_obj_id": "139832116064464"
           },
           "execution_count": 55
         }
@@ -2481,13 +2506,13 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "e7a2d8bf-7fd5-472c-8a97-6d8c9a60b71b",
+        "originalKey": "07bc1cd8-7961-4ec6-8fbd-5b097b7f6bd3",
         "code_folding": [],
         "hidden_ranges": [],
         "collapsed": false,
-        "requestMsgId": "07bc1cd8-7961-4ec6-8fbd-5b097b7f6bd3",
-        "executionStartTime": 1633988335978,
-        "executionStopTime": 1633988335987
+        "requestMsgId": "407ba4c6-3593-4c94-b175-e7740d54cd3c",
+        "executionStartTime": 1634146951652,
+        "executionStopTime": 1634146951684
       },
       "source": [
         "\"End of tutorial\"\n",
@@ -2501,7 +2526,7 @@
             "text/plain": "'End of tutorial'"
           },
           "metadata": {
-            "bento_obj_id": "139691089309936"
+            "bento_obj_id": "139832115157680"
           },
           "execution_count": 56
         }


### PR DESCRIPTION
Summary:
1. Emphasize it creates CPU column by default
2. Use str.upper as example; and removing expanding example for split

Differential Revision: D31615536

