### PR TITLE
Various change to IStringMethods

### DIFF
--- a/torcharrow/istring_column.py
+++ b/torcharrow/istring_column.py
@@ -53,7 +53,7 @@ class IStringMethods(abc.ABC):
 
         return self._vectorize_string(func)
 
-    def split(self, sep=None, maxsplit=-1):
+    def split(self, sep=None):
         """
         Split strings around given separator/delimiter.
 
@@ -79,19 +79,18 @@ class IStringMethods(abc.ABC):
         me = self._parent
 
         def fun(i):
-            return i.split(sep, maxsplit)
+            return i.split(sep)
 
         return self._vectorize_list_string(fun)
 
-    def strip(self, chars=None):
+    def strip(self):
         """
-        Remove leading and trailing characters.
+        Remove leading and trailing whitespaces.
 
-        Strip whitespaces (including newlines) or a set of specified characters
-        from each string in the Column from left and right sides.
-        Equivalent to :meth:`str.strip`.
+        Strip whitespaces (including newlines) from each string in the Column
+        from left and right sides.
         """
-        return self._vectorize_string(lambda s: s.strip(chars))
+        return self._vectorize_string(lambda s: s.strip())
 
     # Check whether all characters in each string are  -----------------------------------------------------
     # alphabetic/numeric/digits/decimal...
@@ -139,97 +138,7 @@ class IStringMethods(abc.ABC):
         """
         return self._vectorize_string(str.upper)
 
-    def title(self) -> IStringColumn:
-        """
-        Convert strings in the Column to titlecase.
-        Equivalent to :meth:`str.title`.
-        """
-        return self._vectorize_string(str.title)
-
-    def capitalize(self):
-        """
-        Convert strings in the Column to be capitalized.
-        Equivalent to :meth:`str.capitalize`.
-
-        Examples
-        --------
-        >>> import torcharrow as ta
-        >>> s = ta.Column(['what a wonderful world!', 'really?'])
-        >>> s.str.capitalize()
-        0  'What a wonderful world!'
-        1  'Really?'
-        dtype: string, length: 2, null_count: 0
-        """
-        return self._vectorize_string(str.capitalize)
-
-    def swapcase(self) -> IStringColumn:
-        """
-        Convert strings in the Column to be swapcased.
-        Equivalent to :meth:`str.swapcase`.
-        """
-        return self._vectorize_string(str.swapcase)
-
-    def casefold(self) -> IStringColumn:
-        """
-        Convert strings in the Column to be casefolded.
-        Equivalent to :meth:`str.casefold`.
-        """
-        return self._vectorize_string(str.casefold)
-
-    # Pad strings in the Column -----------------------------------------------------
-    def pad(self, width, side="left", fillchar=" "):
-        fun = None
-        if side == "left":
-
-            def fun(i):
-                return i.ljust(width, fillchar)
-
-        if side == "right":
-
-            def fun(i):
-                return i.rjust(width, fillchar)
-
-        if side == "center":
-
-            def fun(i):
-                return i.center(width, fillchar)
-
-        return self._vectorize_string(fun)
-
-    def ljust(self, width, fillchar=" "):
-        def fun(i):
-            return i.ljust(width, fillchar)
-
-        return self._vectorize_string(fun)
-
-    def rjust(self, width, fillchar=" "):
-        def fun(i):
-            return i.rjust(width, fillchar)
-
-        return self._vectorize_string(fun)
-
-    def center(self, width, fillchar=" "):
-        def fun(i):
-            return i.center(width, fillchar)
-
-        return self._vectorize_string(fun)
-
-    def zfill(self, width):
-        def fun(i):
-            return i.zfill(width)
-
-        return self._vectorize_string(fun)
-
     # Pattern matching related methods  -----------------------------------------------------
-
-    def count(self, pat):
-        """Count occurrences of pattern in each string"""
-
-        def fun(i):
-            return i.count(pat)
-
-        return self._vectorize_int64(fun)
-
     def startswith(self, pat):
         """Test if the beginning of each string element matches a pattern."""
 
@@ -246,42 +155,17 @@ class IStringMethods(abc.ABC):
 
         return self._vectorize_boolean(pred)
 
-    def find(self, sub, start=0, end=None):
+    def find(self, sub):
         def fun(i):
-            return i.find(sub, start, end)
+            return i.find(sub)
 
         return self._vectorize_int64(fun)
 
-    def rfind(self, sub, start=0, end=None):
-        def fun(i):
-            return i.rfind(sub, start, end)
-
-        return self._vectorize_int64(fun)
-
-    def replace(self, old, new, count=-1):
+    def replace(self, old, new):
         """
         Replace each occurrence of pattern in the Column.
         """
-        return self._vectorize_string(lambda s: s.replace(old, new, count))
-
-    # helper -----------------------------------------------------
-
-    def _vectorize_boolean(self, pred):
-        return self._parent._vectorize(pred, dt.Boolean(self._parent.dtype.nullable))
-
-    def _vectorize_string(self, func):
-        return self._parent._vectorize(func, dt.String(self._parent.dtype.nullable))
-
-    def _vectorize_list_string(self, func):
-        return self._parent._vectorize(
-            func, dt.List(dt.string, self._parent.dtype.nullable)
-        )
-
-    def _vectorize_int64(self, func):
-        return self._parent._vectorize(func, dt.Int64(self._parent.dtype.nullable))
-
-    def _not_supported(self, name):
-        raise TypeError(f"{name} for type {type(self).__name__} is not supported")
+        return self._vectorize_string(lambda s: s.replace(old, new))
 
     # Regular expressions -----------------------------------------------------
     #
@@ -333,3 +217,22 @@ class IStringMethods(abc.ABC):
             return pattern.findall(text)
 
         return self._vectorize_list_string(func)
+
+    # helper -----------------------------------------------------
+
+    def _vectorize_boolean(self, pred):
+        return self._parent._vectorize(pred, dt.Boolean(self._parent.dtype.nullable))
+
+    def _vectorize_string(self, func):
+        return self._parent._vectorize(func, dt.String(self._parent.dtype.nullable))
+
+    def _vectorize_list_string(self, func):
+        return self._parent._vectorize(
+            func, dt.List(dt.string, self._parent.dtype.nullable)
+        )
+
+    def _vectorize_int64(self, func):
+        return self._parent._vectorize(func, dt.Int64(self._parent.dtype.nullable))
+
+    def _not_supported(self, name):
+        raise TypeError(f"{name} for type {type(self).__name__} is not supported")

--- a/torcharrow/test/test_dataframe.py
+++ b/torcharrow/test/test_dataframe.py
@@ -591,9 +591,7 @@ class TestDataFrame(unittest.TestCase):
         df["b"] = [11, 22, 33]
         df["c"] = ["a", "b", "C"]
 
-        self.assertEqual(
-            list(df.where(me["c"].str.capitalize() == me["c"])), [(3, 33, "C")]
-        )
+        self.assertEqual(list(df.where(me["c"].str.upper() == me["c"])), [(3, 33, "C")])
 
     def base_test_locals_and_me_equivalence(self):
         df = self.ts.DataFrame()

--- a/torcharrow/test/test_string_column.py
+++ b/torcharrow/test/test_string_column.py
@@ -95,42 +95,31 @@ class TestStringColumn(unittest.TestCase):
 
         # TODO: also support str + IColumn
 
+    def base_test_comparision(self):
+        s1 = ["abc", "de", "", "f", None]
+        s2 = ["abc", "77", "", None, "55"]
+        c1 = self.ts.Column(s1)
+        c2 = self.ts.Column(s2)
+        self.assertEqual(c1 == c2, [True, False, True, None, None])
+        self.assertEqual(c1 == "abc", [True, False, False, False, None])
+        self.assertEqual(c1 == "de", [False, True, False, False, None])
+
+        # TODO: other comparision, and str == IColumn support
+
     def base_test_string_lifted_methods(self):
-        c = self.ts.Column(dt.string)
         s = ["abc", "de", "", "f"]
-        c = c.append(s)
+        c = self.ts.Column(s)
         self.assertEqual(list(c.str.length()), [len(i) for i in s])
         self.assertEqual(list(c.str.slice(stop=2)), [i[:2] for i in s])
         self.assertEqual(list(c.str.slice(1, 2)), [i[1:2] for i in s])
         self.assertEqual(list(c.str.slice(1)), [i[1:] for i in s])
 
         self.assertEqual(
-            list(self.ts.Column(["UPPER", "lower"]).str.capitalize()),
-            ["Upper", "Lower"],
-        )
-        self.assertEqual(
-            list(self.ts.Column(["UPPER", "lower"]).str.swapcase()), ["upper", "LOWER"]
-        )
-        self.assertEqual(
             list(self.ts.Column(["UPPER", "lower"]).str.lower()), ["upper", "lower"]
         )
         self.assertEqual(
             list(self.ts.Column(["UPPER", "lower"]).str.upper()), ["UPPER", "LOWER"]
         )
-        self.assertEqual(
-            list(self.ts.Column(["UPPER", "lower", "midWife"]).str.casefold()),
-            ["upper", "lower", "midwife"],
-        )
-        self.assertEqual(
-            list(
-                self.ts.Column(["UPPER", "lower", "midWife"]).str.pad(
-                    width=10, side="center", fillchar="_"
-                )
-            ),
-            ["__UPPER___", "__lower___", "_midWife__"],
-        )
-        # ljust, rjust, center
-        self.assertEqual(list(self.ts.Column(["1", "22"]).str.zfill(3)), ["001", "022"])
 
         # strip
         self.assertEqual(
@@ -138,17 +127,19 @@ class TestStringColumn(unittest.TestCase):
         )
 
     def base_test_string_pattern_matching_methods(self):
-        s = ["hello.this", "is.interesting.", "this.is_24", "paradise"]
+        s = ["hello.this", "is.interesting.", "this.is_24", "paradise", "h", ""]
 
-        self.assertEqual(list(self.ts.Column(s).str.count(".")), [1, 2, 1, 0])
         self.assertEqual(
-            list(self.ts.Column(s).str.startswith("h")), [True, False, False, False]
+            list(self.ts.Column(s).str.startswith("h")),
+            [True, False, False, False, True, False],
         )
         self.assertEqual(
-            list(self.ts.Column(s).str.endswith("this")), [True, False, False, False]
+            list(self.ts.Column(s).str.endswith("this")),
+            [True, False, False, False, False, False],
         )
-        self.assertEqual(list(self.ts.Column(s).str.find("this")), [6, -1, 0, -1])
-        self.assertEqual(list(self.ts.Column(s).str.rfind("this")), [6, -1, 0, -1])
+        self.assertEqual(
+            list(self.ts.Column(s).str.find("this")), [6, -1, 0, -1, -1, -1]
+        )
 
         self.assertEqual(
             list(self.ts.Column(s).str.replace("this", "that")),

--- a/torcharrow/test/test_string_column_cpu.py
+++ b/torcharrow/test/test_string_column_cpu.py
@@ -17,6 +17,9 @@ class TestStringColumnCpu(TestStringColumn):
     def test_append_offsets(self):
         self.base_test_append_offsets()
 
+    def test_comparision(self):
+        return self.base_test_comparision()
+
     def test_concat(self):
         return self.base_test_concat()
 

--- a/torcharrow/test/test_string_column_demo.py
+++ b/torcharrow/test/test_string_column_demo.py
@@ -21,6 +21,9 @@ class TestStringColumnDemo(TestStringColumn):
     def test_append_offsets(self):
         self.base_test_append_offsets()
 
+    def test_comparision(self):
+        return self.base_test_comparision()
+
     def test_concat(self):
         return self.base_test_concat()
 


### PR DESCRIPTION
Summary:
1. `length()` and `strip()` to Velox
2. Remove "title", "capitalize", "swapcase", "casefold" -- keep "lower" and "upper" since it's more common and supported by Velox
3. Remove `maxsplit` parameter from `split`: https://github.com/facebookresearch/torcharrow/pull/20/files#r728401859
4. Remove padding related methods -- we may consider add back `ljust` and `rjust` if Presto function `lpad` and `rpad` is added into Velox: https://prestodb.io/docs/current/functions/string.html#lpad
5. Remove `count`, `rfind`
6. Supports `endswith` with Velox
7. Supports equality comparison with Velox

Differential Revision: D31622011

