### PR TITLE
Rename prestosql/CoreFunctions.* to SimpleFunctions.* (#438)

### DIFF
--- a/csrc/velox/lib.cpp
+++ b/csrc/velox/lib.cpp
@@ -12,7 +12,7 @@
 #include "column.h"
 #include "functions/functions.h" // @manual=//pytorch/torcharrow/csrc/velox/functions:torcharrow_functions
 #include "velox/buffer/StringViewBufferHolder.h"
-#include "velox/functions/prestosql/CoreFunctions.h"
+#include "velox/functions/prestosql/SimpleFunctions.h"
 #include "velox/functions/prestosql/VectorFunctions.h"
 #include "velox/vector/TypeAliases.h"
 


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookincubator/velox/pull/438

The new name reflects the contents of the file better and works well with VectorFunctions.h/cpp.

Reviewed By: pedroerp

Differential Revision: D31689803

