### PR TITLE
Remove Scope from user-level interface

### DIFF
--- a/torcharrow/functional.py
+++ b/torcharrow/functional.py
@@ -35,7 +35,7 @@ class _Functional(ModuleType):
             op = self.get_backend_functional(backend).__getattr__(op_name)
             return op(*args)
 
-        def factory_dispatch(*args, size=None, device="cpu", scope=Scope.default):
+        def factory_dispatch(*args, size=None, device="cpu"):
             if size is None:
                 raise AssertionError(
                     f"Factory method call {op_name} requires expclit size parameter"
@@ -50,7 +50,7 @@ class _Functional(ModuleType):
 
             # dispatch to backend functional namespace
             op = self.get_backend_functional(backend).__getattr__(op_name)
-            return op(*args, size=size, device=device, scope=scope)
+            return op(*args, size=size, device=device)
 
         if op_name in self._factory_methods:
             return factory_dispatch

--- a/torcharrow/ilist_column.py
+++ b/torcharrow/ilist_column.py
@@ -18,9 +18,9 @@ from .icolumn import IColumn
 class IListColumn(IColumn):
 
     # private constructor
-    def __init__(self, scope, device, dtype):
+    def __init__(self, device, dtype):
         assert dt.is_list(dtype)
-        super().__init__(scope, device, dtype)
+        super().__init__(device, dtype)
         self.list = IListMethods(self)
 
 

--- a/torcharrow/imap_column.py
+++ b/torcharrow/imap_column.py
@@ -11,9 +11,9 @@ from .icolumn import IColumn
 
 
 class IMapColumn(IColumn):
-    def __init__(self, scope, device, dtype):
+    def __init__(self, device, dtype):
         assert dt.is_map(dtype)
-        super().__init__(scope, device, dtype)
+        super().__init__(device, dtype)
         # must be set by subclasses
         self.maps: IMapMethods = None
 

--- a/torcharrow/interop.py
+++ b/torcharrow/interop.py
@@ -4,33 +4,43 @@ import pyarrow as pa  # type: ignore
 import torcharrow.dtypes as dt
 from torcharrow import Scope
 
+from .dispatcher import Dispatcher
 
-def from_arrow(data, dtype=None, scope=None, device=""):
+
+def from_arrow(data, dtype=None, device=""):
     """
     Convert arrow array/table to a TorchArrow Column/DataFrame.
     """
-    scope = scope or Scope.default
-    device = device or scope.device
+    device = device or Scope.default.device
 
-    return scope.from_arrow(data, dtype, device)
+    import pyarrow as pa
+    from torcharrow._interop import _arrowtype_to_dtype
+
+    assert isinstance(data, pa.Array) or isinstance(data, pa.Table)
+
+    dtype = dtype or _arrowtype_to_dtype(data.type, data.null_count > 0)
+    device = device or Scope.default.device
+
+    call = Dispatcher.lookup((dtype.typecode + "_fromarrow", device))
+
+    return call(device, data, dtype)
 
 
-def from_pandas(data, dtype=None, scope=None, device=""):
+def from_pandas(data, dtype=None, device=""):
     """
     Convert Pandas series/dataframe to a TorchArrow Column/DataFrame.
     """
     raise NotImplementedError
 
 
-def from_torch(data, dtype=None, scope=None, device=""):
+def from_torch(data, dtype=None, device=""):
     raise NotImplementedError
 
 
-def from_pylist(data, dtype=None, scope=None, device=""):
+def from_pylist(data, dtype=None, device=""):
     """
     Convert Python list of scalars or containers to a TorchArrow Column/DataFrame.
     """
-    scope = scope or Scope.default
-    device = device or scope.device
+    device = device or Scope.default.device
 
-    return scope._FromPyList(data, dtype, device)
+    return Scope.default._FromPyList(data, dtype, device)

--- a/torcharrow/inumerical_column.py
+++ b/torcharrow/inumerical_column.py
@@ -3,30 +3,26 @@ import torcharrow.dtypes as dt
 from torcharrow.dispatcher import Device
 
 from .icolumn import IColumn
+from .scope import Scope
 
 
 class INumericalColumn(IColumn):
     """Abstract Numerical Column"""
 
     # private
-    def __init__(self, scope, device, dtype):
+    def __init__(self, device, dtype):
         assert dt.is_boolean_or_numerical(dtype)
-        super().__init__(scope, device, dtype)
+        super().__init__(device, dtype)
 
     # Note all numerical column implementations inherit from INumericalColumn
 
     def to(self, device: Device):
-        from .demo_rt import NumericalColumnDemo
         from .velox_rt import NumericalColumnCpu
 
         if self.device == device:
             return self
-        elif isinstance(self, NumericalColumnDemo):
-            return self.scope._FullColumn(
-                self._data, self.dtype, device=device, mask=self._mask
-            )
         elif isinstance(self, NumericalColumnCpu):
-            return self.scope._FullColumn(
+            return Scope.default._FullColumn(
                 self._data, self.dtype, device=device, mask=self._mask
             )
         else:

--- a/torcharrow/istring_column.py
+++ b/torcharrow/istring_column.py
@@ -17,9 +17,9 @@ from .icolumn import IColumn
 class IStringColumn(IColumn):
 
     # private constructor
-    def __init__(self, scope, device, dtype):  # REP offsets
+    def __init__(self, device, dtype):  # REP offsets
         assert dt.is_string(dtype)
-        super().__init__(scope, device, dtype)
+        super().__init__(device, dtype)
         # must be set by subclass
         self.str: IStringMethods = None
 

--- a/torcharrow/test/test_dataframe_cpu.py
+++ b/torcharrow/test/test_dataframe_cpu.py
@@ -13,7 +13,7 @@ from .test_dataframe import TestDataFrame
 
 class TestDataFrameCpu(TestDataFrame):
     def setUp(self):
-        self.ts = Scope({"device": "cpu"})
+        self.device = "cpu"
 
     def test_internals_empty(self):
         return self.base_test_internals_empty()
@@ -81,6 +81,8 @@ class TestDataFrameCpu(TestDataFrame):
     def test_column_overriden(self):
         return self.base_test_column_overriden()
 
+    def test_infer_func_output_dtype(self):
+        return self.base_test_infer_func_output_dtype()
 
 if __name__ == "__main__":
     unittest.main()

--- a/torcharrow/test/test_functional_cpu.py
+++ b/torcharrow/test/test_functional_cpu.py
@@ -1,6 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import unittest
 
+import torcharrow as ta
 import torcharrow._torcharrow
 import torcharrow.dtypes as dt
 from torcharrow import Scope, IStringColumn
@@ -10,10 +11,12 @@ from torcharrow.velox_rt.functional import velox_functional
 
 class TestStringColumnCpu(unittest.TestCase):
     def setUp(self):
-        self.ts = Scope({"device": "cpu"})
+        self.device = "cpu"
 
     def test_velox_functional(self):
-        str_col = self.ts.Column(["", "abc", "XYZ", "123", "xyz123", None])
+        str_col = ta.Column(
+            ["", "abc", "XYZ", "123", "xyz123", None], device=self.device
+        )
 
         self.assertEqual(
             list(velox_functional.torcharrow_isalpha(str_col)),
@@ -26,7 +29,9 @@ class TestStringColumnCpu(unittest.TestCase):
         )
 
     def test_functional_dispatch(self):
-        str_col = self.ts.Column(["", "abc", "XYZ", "123", "xyz123", None])
+        str_col = ta.Column(
+            ["", "abc", "XYZ", "123", "xyz123", None], device=self.device
+        )
 
         # Test dispatch
         self.assertEqual(

--- a/torcharrow/test/test_list_column_cpu.py
+++ b/torcharrow/test/test_list_column_cpu.py
@@ -10,7 +10,7 @@ from .test_list_column import TestListColumn
 
 class TestListColumnCpu(TestListColumn):
     def setUp(self):
-        self.ts = Scope({"device": "cpu"})
+        self.device = "cpu"
 
     def test_empty(self):
         self.base_test_empty()

--- a/torcharrow/test/test_map_column.py
+++ b/torcharrow/test/test_map_column.py
@@ -3,13 +3,14 @@ import operator
 import unittest
 
 import numpy.testing
+import torcharrow as ta
 import torcharrow.dtypes as dt
 from torcharrow import IMapColumn
 
 
 class TestMapColumn(unittest.TestCase):
     def base_test_map(self):
-        c = self.ts.Column(dt.Map(dt.string, dt.int64))
+        c = ta.Column(dt.Map(dt.string, dt.int64), device=self.device)
         self.assertIsInstance(c, IMapColumn)
 
         c = c.append([{"abc": 123}])
@@ -19,12 +20,13 @@ class TestMapColumn(unittest.TestCase):
         self.assertDictEqual(c[1], {"de": 45, "fg": 67})
 
     def base_test_infer(self):
-        c = self.ts.Column(
+        c = ta.Column(
             [
                 {"helsinki": [-1.0, 21.0], "moscow": [-4.0, 24.0]},
                 {},
                 {"nowhere": [], "algiers": [11.0, 25, 2], "kinshasa": [22.0, 26.0]},
-            ]
+            ],
+            device=self.device,
         )
         self.assertIsInstance(c, IMapColumn)
         self.assertEqual(len(c), 3)
@@ -40,7 +42,7 @@ class TestMapColumn(unittest.TestCase):
         )
 
     def base_test_keys_values_get(self):
-        c = self.ts.Column([{"abc": 123}, {"de": 45, "fg": 67}])
+        c = ta.Column([{"abc": 123}, {"de": 45, "fg": 67}], device=self.device)
 
         self.assertEqual(list(c.maps.keys()), [["abc"], ["de", "fg"]])
         self.assertEqual(list(c.maps.values()), [[123], [45, 67]])

--- a/torcharrow/test/test_map_column_cpu.py
+++ b/torcharrow/test/test_map_column_cpu.py
@@ -10,7 +10,7 @@ from .test_map_column import TestMapColumn
 
 class TestMapColumnCpu(TestMapColumn):
     def setUp(self):
-        self.ts = Scope({"device": "cpu"})
+        self.device = "cpu"
 
     def test_map(self):
         self.base_test_map()

--- a/torcharrow/test/test_numerical_column_cpu.py
+++ b/torcharrow/test/test_numerical_column_cpu.py
@@ -10,7 +10,7 @@ from .test_numerical_column import TestNumericalColumn
 
 class TestNumericalColumnCpu(TestNumericalColumn):
     def setUp(self):
-        self.ts = Scope({"device": "cpu"})
+        self.device = "cpu"
 
     def test_internal_empty(self):
         c = self.base_test_empty()

--- a/torcharrow/test/test_string_column_cpu.py
+++ b/torcharrow/test/test_string_column_cpu.py
@@ -9,7 +9,7 @@ from .test_string_column import TestStringColumn
 
 class TestStringColumnCpu(TestStringColumn):
     def setUp(self):
-        self.ts = Scope({"device": "cpu"})
+        self.device = "cpu"
 
     def test_empty(self):
         self.base_test_empty()

--- a/torcharrow/trace.py
+++ b/torcharrow/trace.py
@@ -79,14 +79,7 @@ class Trace:
 def get_trace(*args, **kwargs):
     from .scope import Scope
 
-    for arg in args:
-        if isinstance(arg, Scope):
-            return arg.trace
-        if hasattr(arg, "_scope") and isinstance(arg._scope, Scope):
-            return arg._scope.trace
-        elif "scope" in kwargs and isinstance(kwargs["scope"], Scope):
-            return kwargs["scope"].trace
-    return None
+    return Scope.default.trace
 
 
 def trace(fn):

--- a/torcharrow/velox_rt/column.py
+++ b/torcharrow/velox_rt/column.py
@@ -1,9 +1,9 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import torcharrow._torcharrow as velox
+from torcharrow import Scope
 from torcharrow.dispatcher import Device
 from torcharrow.dtypes import DType
 from torcharrow.icolumn import IColumn
-from torcharrow.scope import Scope
 
 
 class ColumnFromVelox:
@@ -12,13 +12,12 @@ class ColumnFromVelox:
 
     @staticmethod
     def from_velox(
-        scope: Scope,
         device: Device,
         dtype: DType,
         data: velox.BaseColumn,
         finialized: bool,
     ) -> IColumn:
-        col = scope.Column(dtype=dtype, device=device)
+        col = Scope._Column(dtype=dtype, device=device)
         col._data = data
         col._finialized = finialized
         return col
@@ -27,5 +26,5 @@ class ColumnFromVelox:
     # This help method allows to alter it based on context (e.g. methods in IStringMethods can have better inference)
     def with_null(self, nullable: bool):
         return self.from_velox(
-            self.scope, self.device, self.dtype.with_null(nullable), self._data, True
+            self.device, self.dtype.with_null(nullable), self._data, True
         )

--- a/torcharrow/velox_rt/functional.py
+++ b/torcharrow/velox_rt/functional.py
@@ -38,10 +38,10 @@ class VeloxFunctional(types.ModuleType):
             result_dtype = result_col.dtype().with_null(True)
 
             return ColumnFromVelox.from_velox(
-                first_col.scope, first_col.device, result_dtype, result_col, True
+                first_col.device, result_dtype, result_col, True
             )
 
-        def factory_dispatch(*args, size=None, device="cpu", scope=Scope.default):
+        def factory_dispatch(*args, size=None, device="cpu"):
             if size is None:
                 raise AssertionError(
                     f"Factory method call {op_name} requires expclit size parameter"
@@ -57,9 +57,7 @@ class VeloxFunctional(types.ModuleType):
             # Generic dispatch always assumes nullable
             result_dtype = result_col.dtype().with_null(True)
 
-            return ColumnFromVelox.from_velox(
-                scope, device, result_dtype, result_col, True
-            )
+            return ColumnFromVelox.from_velox(device, result_dtype, result_col, True)
 
         if op_name in functional_registry._factory_methods:
             return factory_dispatch


### PR DESCRIPTION
Differential Revision: D31917078

Scope an experimental feature in TorchArrow -- it tries to avoid global state/configuration.  It's somewhat similar to a browser's session: 
* Each time you want to write a new TA program you start a new scope (session), and all the DF/column are created from that scope. 
* DF/Column created from different scope cannot interact with each other. 
* Scope can trace all the activities for later analysis. 

However, in practice we found inconvenient for users to always first creates a scope, and make sure use the same scope during the program.

So we will switch to use the classic and well-understood config design. In fact, the eager mode TorchArrow almost always use  `Scope.default`, which basically becomes the de-factor global config and beat the original purpose of scope. 

This diff doesn't fully deprecate `Scope` but only remove `Scope` from `IColumn` and public interface. Fully deprecating Scope is left as future work. 
