### PR TITLE
Doc update

### DIFF
--- a/.github/workflows/deploy-doc.yml
+++ b/.github/workflows/deploy-doc.yml
@@ -1,0 +1,39 @@
+name: Deploy Doc
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Setup Python environment
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Check out source repository
+        uses: actions/checkout@v2
+        with:
+            ref: "release/0.1.0"
+            submodules: recursive
+
+      - name: Install TorchArrow
+        run: |
+          pip install --pre torcharrow -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+
+      - name: Build the docs
+        run: |
+          cd ./docs
+          pip install -r requirements.txt --user
+          make html
+          cd ..
+
+      - name: Deploy Docs on Push
+        uses: JamesIves/github-pages-deploy-action@v4.2.5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: gh-pages # The branch the action should deploy to.
+          folder: docs/build/html # The folder the action should deploy.
+          target-folder: 0.1.0

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -77,18 +77,3 @@ jobs:
       - name : Install TorchArrow
         run: |
           CCACHE_DIR=$GITHUB_WORKSPACE/.ccache python setup.py install --user
-        
-      - name: Build the docs
-        run: |
-          cd ./docs
-          pip3 install -r requirements.txt --user
-          make html 
-          cd ..
-
-      - name: Deploy Docs on Push
-        if: ${{ github.event_name == 'push' }}
-        uses: JamesIves/github-pages-deploy-action@releases/v3
-        with:
-          ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages # The branch the action should deploy to.
-          FOLDER: docs/build/html # The folder the action should deploy.

--- a/docs/source/column.rst
+++ b/docs/source/column.rst
@@ -3,8 +3,8 @@
 torcharrow.Column
 ==========================
 
-A :class:`torcharrow.Column` is a 1-dimension torch.Tensor like data structure containing 
-elements of a single data type. It also supports non-numeric types such as string, 
+A :class:`torcharrow.Column` is a 1-dimension torch.Tensor like data structure containing
+elements of a single data type. It also supports non-numeric types such as string,
 list, struct.
 
 Data types
@@ -40,6 +40,7 @@ Column class reference
 .. autosummary::
     :toctree: generated
     :nosignatures:
+    :template: class.rst
 
     Column.head
     Column.tail
@@ -63,7 +64,7 @@ Column class reference
     Column.to_arrow
     Column.to_tensor
     Column.to_pylist
-    Column.to_pandas    
+    Column.to_pandas
 
 
 NumericalColumn class reference
@@ -73,6 +74,7 @@ NumericalColumn class reference
 .. autosummary::
     :toctree: generated
     :nosignatures:
+    :template: class.rst
 
     NumericalColumn.abs
     NumericalColumn.ceil
@@ -96,34 +98,35 @@ StringColumn class reference
 .. autosummary::
     :toctree: generated
     :nosignatures:
+    :template: class.rst
 
-    torcharrow.istring_column.StringMethods.length
-    torcharrow.istring_column.StringMethods.slice
-    torcharrow.istring_column.StringMethods.split
-    torcharrow.istring_column.StringMethods.strip
+    istring_column.StringMethods.length
+    istring_column.StringMethods.slice
+    istring_column.StringMethods.split
+    istring_column.StringMethods.strip
 
-    torcharrow.istring_column.StringMethods.isalpha
-    torcharrow.istring_column.StringMethods.isnumeric
-    torcharrow.istring_column.StringMethods.isalnum
-    torcharrow.istring_column.StringMethods.isdigit
-    torcharrow.istring_column.StringMethods.isdecimal
-    torcharrow.istring_column.StringMethods.isspace
-    torcharrow.istring_column.StringMethods.islower
-    torcharrow.istring_column.StringMethods.isupper
-    torcharrow.istring_column.StringMethods.istitle
+    istring_column.StringMethods.isalpha
+    istring_column.StringMethods.isnumeric
+    istring_column.StringMethods.isalnum
+    istring_column.StringMethods.isdigit
+    istring_column.StringMethods.isdecimal
+    istring_column.StringMethods.isspace
+    istring_column.StringMethods.islower
+    istring_column.StringMethods.isupper
+    istring_column.StringMethods.istitle
 
-    torcharrow.istring_column.StringMethods.lower
-    torcharrow.istring_column.StringMethods.upper
+    istring_column.StringMethods.lower
+    istring_column.StringMethods.upper
 
-    torcharrow.istring_column.StringMethods.startswith
-    torcharrow.istring_column.StringMethods.endswith
-    torcharrow.istring_column.StringMethods.count
-    torcharrow.istring_column.StringMethods.find
-    torcharrow.istring_column.StringMethods.replace
-    torcharrow.istring_column.StringMethods.match
-    torcharrow.istring_column.StringMethods.contains
-    torcharrow.istring_column.StringMethods.findall
-    
+    istring_column.StringMethods.startswith
+    istring_column.StringMethods.endswith
+    istring_column.StringMethods.count
+    istring_column.StringMethods.find
+    istring_column.StringMethods.replace
+    istring_column.StringMethods.match
+    istring_column.StringMethods.contains
+    istring_column.StringMethods.findall
+
 ListColumn class reference
 -----------------------------------
 .. class:: ListColumn()
@@ -131,7 +134,8 @@ ListColumn class reference
 .. autosummary::
     :toctree: generated
     :nosignatures:
+    :template: class.rst
 
-    torcharrow.ilist_column.ListMethods.length
-    torcharrow.ilist_column.ListMethods.slice
-    torcharrow.ilist_column.ListMethods.vmap
+    ilist_column.ListMethods.length
+    ilist_column.ListMethods.slice
+    ilist_column.ListMethods.vmap

--- a/docs/source/dataframe.rst
+++ b/docs/source/dataframe.rst
@@ -25,6 +25,7 @@ DataFrame Class and General APIs
 .. autosummary::
     :toctree: generated
     :nosignatures:
+    :template: class.rst
 
     DataFrame.head
     DataFrame.tail
@@ -42,6 +43,7 @@ Functional API
 .. autosummary::
     :toctree: generated
     :nosignatures:
+    :template: function.rst
 
     DataFrame.map
     DataFrame.filter
@@ -54,6 +56,7 @@ Relational API
 .. autosummary::
     :toctree: generated
     :nosignatures:
+    :template: function.rst
 
     DataFrame.select
     DataFrame.where
@@ -64,6 +67,7 @@ Data Cleaning
 .. autosummary::
     :toctree: generated
     :nosignatures:
+    :template: function.rst
 
     DataFrame.fill_null
     DataFrame.drop_null
@@ -74,6 +78,7 @@ Conversions
 .. autosummary::
     :toctree: generated
     :nosignatures:
+    :template: function.rst
 
     DataFrame.to_arrow
     DataFrame.to_tensor
@@ -85,6 +90,7 @@ Statistics
 .. autosummary::
     :toctree: generated
     :nosignatures:
+    :template: function.rst
 
     DataFrame.min
     DataFrame.max
@@ -100,5 +106,6 @@ Arithmtic Operations
 .. autosummary::
     :toctree: generated
     :nosignatures:
+    :template: function.rst
 
     DataFrame.log

--- a/docs/source/functional.rst
+++ b/docs/source/functional.rst
@@ -37,6 +37,7 @@ Recommendation Operations
 .. autosummary::
     :toctree: generated
     :nosignatures:
+    :template: function.rst
 
     bucketize
     sigrid_hash
@@ -55,5 +56,6 @@ High-level Operations
 .. autosummary::
     :toctree: generated
     :nosignatures:
+    :template: function.rst
 
     scale_to_0_1

--- a/docs/source/torcharrow.rst
+++ b/docs/source/torcharrow.rst
@@ -4,8 +4,8 @@ torcharrow
 ==========================
 
 The torcharrow package contains data structures for two-dimensional, potentially heterogeneous tabular data,
-denoted as dataframe. 
-It also defines relational operations over these dataframes. 
+denoted as dataframe.
+It also defines relational operations over these dataframes.
 Additionally, it provides utilities for conversion with other formats (especially zero-copy conversion with Arrow arrays),
 and other useful utilities.
 
@@ -28,4 +28,3 @@ Mutating Ops
 
     concat
     if_else
-


### PR DESCRIPTION
Changes in this PR:
* Put doc build and deploy into a separate workflow, so it doesn't run every time with a push. It also uploads the docs to the beta folder, which is accordingly created and linked in gh-pages branch.
* Added template parameters in the .rst files as @NivekT suggested.
*  For the `istring_column.StringMethods` for now the best I could do is just removing the torcharrow prefix. I feel it's sort of related to the fact that StringMethods is not part of StringColumn. Importing it with an alias did not seem to work. We can keep investigating to find the best way to present it in the doc.