### PR TITLE
Enable automatic type deduction for columns built from lists of dataframes.

### DIFF
--- a/torcharrow/test/test_list_column.py
+++ b/torcharrow/test/test_list_column.py
@@ -208,6 +208,19 @@ class TestListColumn(unittest.TestCase):
             f"Unexpected failure reason: {str(ex.exception)}",
         )
 
+    def base_test_column_from_dataframe_list(self):
+        a = ta.dataframe({"a": [1, 2, 3, 4], "b": [5, 6, 7, 8]})
+        b = ta.column([a, a])
+        self.assertEqual(
+            list(b),
+            [[(1, 5), (2, 6), (3, 7), (4, 8)], [(1, 5), (2, 6), (3, 7), (4, 8)]],
+        )
+        self.assertEqual(
+            b.dtype,
+            dt.List(dt.Struct([dt.Field("a", dt.int64), dt.Field("b", dt.int64)])),
+        )
+        self.assertTrue(isinstance(b, ta.velox_rt.list_column_cpu.ListColumnCpu))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/torcharrow/test/test_list_column_cpu.py
+++ b/torcharrow/test/test_list_column_cpu.py
@@ -46,6 +46,9 @@ class TestListColumnCpu(TestListColumn):
     def test_fixed_size_list(self):
         self.base_test_fixed_size_list()
 
+    def test_column_from_dataframe_list(self):
+        self.base_test_column_from_dataframe_list()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary:
Enable type inference functions to automatically deduce the row types when a
column is built from a list of dataframe objects without supplying the "dtype"
parameter.

REMARKS:
1. The same issue occurs when supplying a list of columns as input rather than
a list of dataframes. This will be addressed in a subsequent commit once this
diff is reviewed.

2. The "ta.velox_rt.list_column_cpu.ListColumnCpu" import is placed in an awkward
location because of a circular import issue.

Reviewed By: OswinC

Differential Revision: D37240169

