### PR TITLE
Minor changes to setup scripts

### DIFF
--- a/scripts/_setup-macos.sh
+++ b/scripts/_setup-macos.sh
@@ -27,7 +27,7 @@ set -x # Print commands that are executed.
 SCRIPTDIR=$(dirname "${BASH_SOURCE[0]}")
 source $SCRIPTDIR/../csrc/velox/velox/scripts/setup-helper-functions.sh
 
-FB_OS_VERSION=v2021.05.10.00
+FB_OS_VERSION=v2022.03.14.00
 NPROC=$(sysctl -n hw.physicalcpu)
 COMPILER_FLAGS=$(get_cxx_flags $CPU_TARGET)
 DEPENDENCY_DIR=${DEPENDENCY_DIR:-$(pwd)}
@@ -107,7 +107,7 @@ function install_build_prerequisites {
 }
 
 function install_fmt {
-  github_checkout fmtlib/fmt 7.1.3
+  github_checkout fmtlib/fmt 8.0.0
   cmake_install -DFMT_TEST=OFF
 }
 
@@ -130,12 +130,12 @@ function install_folly {
 
 function install_ranges_v3 {
   github_checkout ericniebler/range-v3 0.12.0
-  cmake_install -DRANGES_ENABLE_WERROR=OFF
+  cmake_install -DRANGES_ENABLE_WERROR=OFF -DRANGE_V3_TESTS=OFF -DRANGE_V3_EXAMPLES=OFF
 }
 
 function install_re2 {
   github_checkout google/re2 2021-04-01
-  cmake_install
+  cmake_install -DRE2_BUILD_TESTING=OFF
 }
 
 function install_velox_deps {
@@ -143,7 +143,6 @@ function install_velox_deps {
     run_and_time install_build_prerequisites
   fi
   run_and_time install_ranges_v3
-  run_and_time install_googletest
   run_and_time install_fmt
   run_and_time install_double_conversion
   run_and_time install_folly

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -21,7 +21,7 @@ source $SCRIPTDIR/../csrc/velox/velox/scripts/setup-helper-functions.sh
 
 CPU_TARGET="${CPU_TARGET:-avx}"
 export COMPILER_FLAGS=$(get_cxx_flags $CPU_TARGET)
-FB_OS_VERSION=v2021.05.10.00
+FB_OS_VERSION=v2022.03.14.00
 NPROC=$(getconf _NPROCESSORS_ONLN)
 DEPENDENCY_DIR=${DEPENDENCY_DIR:-$(pwd)}
 
@@ -88,7 +88,7 @@ function cmake_install {
 }
 
 function install_fmt {
-  github_checkout fmtlib/fmt 7.1.3
+  github_checkout fmtlib/fmt 8.0.0
   cmake_install -DFMT_TEST=OFF
 }
 


### PR DESCRIPTION
* Update folly version to be consistent with Velox: https://github.com/facebookincubator/velox/blob/c4237370e40fce925a5c34bd805008248d42684f/scripts/setup-ubuntu.sh#L25
* Minor config flag change (e.g. disable testing), following https://github.com/facebookincubator/velox/blob/04a85f7cb7fcc2eaa3b30b1749c3d97b3bba8676/scripts/setup-macos.sh#L104
and  https://github.com/facebookincubator/velox/blob/04a85f7cb7fcc2eaa3b30b1749c3d97b3bba8676/scripts/setup-macos.sh#L109