### PR TITLE
Pin range_v3 version to 0.12.0

### DIFF
--- a/scripts/_setup-macos.sh
+++ b/scripts/_setup-macos.sh
@@ -129,7 +129,7 @@ function install_folly {
 }
 
 function install_ranges_v3 {
-  github_checkout ericniebler/range-v3 master
+  github_checkout ericniebler/range-v3 0.12.0
   cmake_install -DRANGES_ENABLE_WERROR=OFF
 }
 


### PR DESCRIPTION
Mac CI starts to fail today with
```
/Users/runner/work/torcharrow/torcharrow/_build/range-v3/include/meta/meta.hpp:30:32: error: unknown warning group '-Wreserved-identifier', ignored [-Werror,-Wunknown-warning-option]
```

Suspect
https://github.com/ericniebler/range-v3/commit/149e4a19c7b609aa79ae30b3ac69aebf17ab8f61
is the culprit. In any case use master version seems fragile.