### PR TITLE
Fix arrow schema conversion for complex types (#1857)

### DIFF
--- a/csrc/velox/column.h
+++ b/csrc/velox/column.h
@@ -22,6 +22,7 @@
 #include "velox/vector/BaseVector.h"
 #include "velox/vector/ComplexVector.h"
 #include "velox/vector/FlatVector.h"
+#include "velox/vector/arrow/Abi.h"
 #include "velox/vector/arrow/Bridge.h"
 
 // TODO: Move uses of static variables into .cpp. Static variables are local to

--- a/csrc/velox/lib.cpp
+++ b/csrc/velox/lib.cpp
@@ -25,6 +25,7 @@
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
 #include "velox/type/Type.h"
 #include "velox/vector/TypeAliases.h"
+#include "velox/vector/arrow/Abi.h"
 #include "velox/vector/arrow/Bridge.h"
 
 #ifdef USE_TORCH


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/1857

1. Use `List` instead of `LargeList` because `vector_size_t` is 32 bits large.
2. Fix the conversion of `Map`; arrow requires an extra layer of struct type between the map type and key-value types.

Differential Revision: D37356848

