### PR TITLE
Remove install step in ubuntu.yml

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -73,7 +73,3 @@ jobs:
 
       - name : Run TorchArrow unit tests
         run: pytest --no-header -v torcharrow/test
-
-      - name : Install TorchArrow
-        run: |
-          CCACHE_DIR=$GITHUB_WORKSPACE/.ccache python setup.py install --user


### PR DESCRIPTION
It's used to generate docs. Since we no longer generate docs per commit
(71f9c1a35f308969fcbe52198186605695aaf89b), we can also remove this to
save some time on CI test.