### PR TITLE
Update fbsync 

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,10 +1,11 @@
 name: MacOS Build and Test
 on:
   push:
-    branches: [ main ]
+    branches: [ main, fbsync ]
   pull_request:
     branches:
       - main
+      - fbsync
       # For PR created by ghstack
       - gh/*/*/base
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,10 +1,11 @@
 name: Ubuntu Build and Test
 on:
   push:
-    branches: [ main ]
+    branches: [ main, fbsync ]
   pull_request:
     branches:
       - main
+      - fbsync
       # For PR created by ghstack
       - gh/*/*/base
 


### PR DESCRIPTION
Mainly to update GH workflow, since CI is not triggered on fbsync branch somehow. 

Generated via 
```
git cherry-pick 4d9e90af28bcb7bf97278f26008d6254d473baef^..5732d84b99b669499cb73295dc9237d6c76dc47c
```

on a fork of `fbsync` branch