### PR TITLE
Pass not nullable context and results by reference (#2367)

### DIFF
--- a/csrc/velox/column.cpp
+++ b/csrc/velox/column.cpp
@@ -452,7 +452,7 @@ std::unique_ptr<BaseColumn> OperatorHandle::call(
       &TorchArrowGlobalStatic::execContext(), exprSet_.get(), inputRows.get());
   velox::SelectivityVector select(size);
   std::vector<velox::VectorPtr> outputRows(1);
-  exprSet_->eval(0, 1, true, select, &evalCtx, &outputRows);
+  exprSet_->eval(0, 1, true, select, evalCtx, outputRows);
 
   // TODO: This causes an extra type-based dispatch.
   // We can optimize it by template OperatorHandle by return type


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/2367

Those are always assumed not null and de-referenced with out
checking, hence passing them by reference is more suitable.

Differential Revision: D38946493

