### PR TITLE
Use rootMemoryPool to construct execContext

### DIFF
--- a/csrc/velox/column.cpp
+++ b/csrc/velox/column.cpp
@@ -553,9 +553,9 @@ velox::core::QueryCtx& TorchArrowGlobalStatic::queryContext() {
 }
 
 velox::core::ExecCtx& TorchArrowGlobalStatic::execContext() {
-  static auto pool = velox::memory::getDefaultScopedMemoryPool();
   static velox::core::ExecCtx execContext(
-      pool.get(), &TorchArrowGlobalStatic::queryContext());
+      TorchArrowGlobalStatic::rootMemoryPool(),
+      &TorchArrowGlobalStatic::queryContext());
   return execContext;
 }
 


### PR DESCRIPTION
Summary:
It originally use `memory::getDefaultScopedMemoryPool()` since `ExecCtx`
 constructor expects `unique_ptr<MemoryPool>`.

Since https://github.com/facebookincubator/velox/commit/15eeddb8e7d50de39afdbde4049f9a1310edf5e5,
`ExecCtx` now expects `MemoryPool*`, so we can use
`&velox::memory::getProcessDefaultMemoryManager().getRoot()` returned by
`TorchArrowGlobalStatic::rootMemoryPool`.

This makes TorchArrow always use this process default root memory pool.

Differential Revision: D39010989

