### PR TITLE
Update Velox submodule

### DIFF
--- a/csrc/velox/column.cpp
+++ b/csrc/velox/column.cpp
@@ -452,7 +452,7 @@ std::unique_ptr<BaseColumn> OperatorHandle::call(
       &TorchArrowGlobalStatic::execContext(), exprSet_.get(), inputRows.get());
   velox::SelectivityVector select(size);
   std::vector<velox::VectorPtr> outputRows(1);
-  exprSet_->eval(0, 1, true, select, &evalCtx, &outputRows);
+  exprSet_->eval(0, 1, true, select, evalCtx, outputRows);
 
   // TODO: This causes an extra type-based dispatch.
   // We can optimize it by template OperatorHandle by return type


### PR DESCRIPTION
Update to https://github.com/facebookincubator/velox/commit/9657cd75740d5d62dc528909ef219b3ad22e0c5f,
which update ExprSet::eval API

Also cherry-pick https://github.com/pytorch/torcharrow/commit/458dc0bcbc778b6957afb08248c86f2a5ceaead1
to update the API usage.