### PR TITLE
Decouple the building of benchmarks and tests (#2439)

### DIFF
--- a/csrc/velox/functions/rec/tests/BucketizeTest.cpp
+++ b/csrc/velox/functions/rec/tests/BucketizeTest.cpp
@@ -14,10 +14,10 @@
 
 #include <velox/common/base/VeloxException.h>
 #include <velox/vector/SimpleVector.h>
-#include <velox/vector/tests/VectorTestBase.h>
+#include <velox/vector/tests/utils/VectorTestBase.h>
 
 #include "pytorch/torcharrow/csrc/velox/functions/functions.h"
-#include "velox/functions/prestosql/tests/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
 #include "velox/parse/TypeResolver.h"
 
 namespace facebook::velox {

--- a/csrc/velox/functions/rec/tests/ComputeScoreTest.cpp
+++ b/csrc/velox/functions/rec/tests/ComputeScoreTest.cpp
@@ -14,10 +14,10 @@
 
 #include <velox/common/base/VeloxException.h>
 #include <velox/vector/SimpleVector.h>
-#include <velox/vector/tests/VectorMaker.h>
+#include <velox/vector/tests/utils/VectorMaker.h>
 
 #include "pytorch/torcharrow/csrc/velox/functions/functions.h"
-#include "velox/functions/prestosql/tests/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
 #include "velox/parse/TypeResolver.h"
 
 namespace facebook::velox {

--- a/csrc/velox/functions/rec/tests/FirstXTest.cpp
+++ b/csrc/velox/functions/rec/tests/FirstXTest.cpp
@@ -14,10 +14,10 @@
 
 #include <velox/common/base/VeloxException.h>
 #include <velox/vector/SimpleVector.h>
-#include <velox/vector/tests/VectorTestBase.h>
+#include <velox/vector/tests/utils/VectorTestBase.h>
 
 #include "pytorch/torcharrow/csrc/velox/functions/functions.h"
-#include "velox/functions/prestosql/tests/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
 #include "velox/parse/TypeResolver.h"
 
 namespace facebook::velox {

--- a/csrc/velox/functions/rec/tests/SigridHashTest.cpp
+++ b/csrc/velox/functions/rec/tests/SigridHashTest.cpp
@@ -14,10 +14,10 @@
 
 #include <velox/common/base/VeloxException.h>
 #include <velox/vector/SimpleVector.h>
-#include <velox/vector/tests/VectorMaker.h>
+#include <velox/vector/tests/utils/VectorMaker.h>
 
 #include "pytorch/torcharrow/csrc/velox/functions/functions.h"
-#include "velox/functions/prestosql/tests/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
 #include "velox/parse/TypeResolver.h"
 
 namespace facebook::velox {

--- a/csrc/velox/functions/tests/FunctionsTest.cpp
+++ b/csrc/velox/functions/tests/FunctionsTest.cpp
@@ -15,7 +15,7 @@
 #include <velox/common/base/VeloxException.h>
 #include <velox/vector/SimpleVector.h>
 #include "pytorch/torcharrow/csrc/velox/functions/functions.h"
-#include "velox/functions/prestosql/tests/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
 #include "velox/parse/TypeResolver.h"
 
 namespace facebook::velox {


### PR DESCRIPTION
Summary:
Tests and benchmarks targets are now de-coupled.
That means they can be built independently.
Shared functionality is moved to a common utility library.

Resolves https://github.com/facebookincubator/velox/issues/1704

X-link: https://github.com/facebookincubator/velox/pull/2439

Reviewed By: Yuhta

Differential Revision: D39484543

Pulled By: kgpai

