### PR TITLE
Type-annotate dtypes.promote()

### DIFF
--- a/torcharrow/dtypes.py
+++ b/torcharrow/dtypes.py
@@ -364,7 +364,7 @@ _promotion_list = [
 ]
 
 
-def promote(l, r):
+def promote(l: DType, r: DType) -> ty.Optional[DType]:
     assert is_boolean_or_numerical(l) and is_boolean_or_numerical(r)
 
     lt = l.typecode


### PR DESCRIPTION
Summary: `dtypes.promote()` is not typed. Fix it

Differential Revision: D40330862

