### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Prepare ccache timestamp
         id: ccache_cache_timestamp
         run: |
-          echo "::set-output name=timestamp::$(/bin/date -u "+%Y%m%d-%H:%M:%S")"
+          echo "timestamp=$(/bin/date -u "+%Y%m%d-%H:%M:%S")" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Load ccache files

--- a/.github/workflows/nightly-conda.yml
+++ b/.github/workflows/nightly-conda.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Prepare ccache timestamp
         id: ccache_cache_timestamp
         run: |
-          echo "::set-output name=timestamp::$(/bin/date -u "+%Y%m%d-%H:%M:%S")"
+          echo "timestamp=$(/bin/date -u "+%Y%m%d-%H:%M:%S")" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Load ccache files

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Prepare ccache timestamp
         id: ccache_cache_timestamp
         run: |
-          echo "::set-output name=timestamp::$(/bin/date -u "+%Y%m%d-%H:%M:%S")"
+          echo "timestamp=$(/bin/date -u "+%Y%m%d-%H:%M:%S")" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Load ccache files


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter