### PR TITLE
fix sigmoid implementation bug

### DIFF
--- a/csrc/velox/functions/numeric_functions.h
+++ b/csrc/velox/functions/numeric_functions.h
@@ -192,7 +192,7 @@ struct sigmoid {
   template <typename TOutput, typename TInput = TOutput>
   FOLLY_ALWAYS_INLINE bool call(TOutput& result, const TInput& x) {
     if (x >= 0) {
-      result = 1 / (1 + exp(x));
+      result = 1 / (1 + exp(-x));
     } else {
       const auto z = exp(x);
       result = z / (1 + z);


### PR DESCRIPTION
sigmoid(x) = 1 / (1+exp(-x))

The original implementation does not have `-`.